### PR TITLE
fixed possible error due to floating point inaccuracies

### DIFF
--- a/src/pca.jl
+++ b/src/pca.jl
@@ -19,7 +19,7 @@ function PCA{T<:FloatingPoint}(mean::Vector{T}, proj::Matrix{T}, pvars::Vector{T
     length(pvars) == p ||
         throw(DimensionMismatch("Dimensions of proj and pvars are inconsistent."))
     tpvar = sum(pvars)
-    tpvar <= tvar || throw(ArgumentError("principal variance cannot exceed total variance."))
+    tpvar <= tvar || isapprox(tpvar,tvar) || throw(ArgumentError("principal variance cannot exceed total variance."))
     PCA(mean, proj, pvars, tpvar, tvar)
 end
 


### PR DESCRIPTION
Due to floating point inaccuracies, the sum of principal variances can slightly exceed  the total variance.

https://github.com/JuliaStats/MultivariateStats.jl/issues/17