### PR TITLE
Update tests to new row slicing and cov behavior. 

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.3
-Compat
+Compat 0.7.12
 ArrayViews 0.5.0
 StatsBase 0.7.0

--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -5,7 +5,7 @@ module MultivariateStats
 
     import Base: length, size, show, dump, sumabs2
     import Base.LinAlg: Cholesky
-    import StatsBase: fit, predict, evaluate
+    import StatsBase: fit, predict
 
     export
 

--- a/src/cmds.jl
+++ b/src/cmds.jl
@@ -29,7 +29,7 @@ gram2dmat{T<:Real}(G::AbstractMatrix{T}) = gram2dmat!(similar(G, Base.momenttype
 
 function dmat2gram!{GT}(G::AbstractMatrix{GT}, D::AbstractMatrix)
     # argument checking
-    n = Base.LinAlg.chksquare(D)
+    n = Compat.LinAlg.checksquare(D)
     size(G) == (n, n) ||
         throw(DimensionMismatch("Sizes of G and D do not match."))
 

--- a/src/pca.jl
+++ b/src/pca.jl
@@ -148,7 +148,11 @@ function fit{T<:AbstractFloat}(::Type{PCA}, X::DenseMatrix{T};
 
     # delegate to core
     if method == :cov
-        C = cov(X; vardim=2, mean=isempty(mv) ? 0 : mv)::Matrix{T}
+        if VERSION < v"0.5.0-dev+660"
+            C = cov(X; vardim=2, mean=isempty(mv) ? 0 : mv)::Matrix{T}
+        else
+            C = Base.covm(X, isempty(mv) ? 0 : mv, 2)
+        end
         M = pcacov(C, mv; maxoutdim=maxoutdim, pratio=pratio)
     elseif method == :svd
         Z = centralize(X, mv)

--- a/src/whiten.jl
+++ b/src/whiten.jl
@@ -28,15 +28,15 @@ cov_whitening{T<:AbstractFloat}(C::DenseMatrix{T}, regcoef::Real) =
 immutable Whitening{T<:AbstractFloat}
     mean::Vector{T}
     W::Matrix{T}
-end
-
-function Whitening{T<:AbstractFloat}(mean::Vector{T}, W::Matrix{T})
-    d, d2 = size(W)
-    d == d2 || error("W must be a square matrix.")
-    isempty(mean) || length(mean) == d ||
+    function Whitening(mean::Vector{T}, W::Matrix{T})
+        d, d2 = size(W)
+        d == d2 || error("W must be a square matrix.")
+        isempty(mean) || length(mean) == d ||
         throw(DimensionMismatch("Sizes of mean and W are inconsistent."))
-    return Whitening{T}(mean, W)
+        return new(mean, W)
+    end
 end
+Whitening{T<:AbstractFloat}(mean::Vector{T}, W::Matrix{T}) = Whitening{T}(mean, W)
 
 indim(f::Whitening) = size(f.W, 1)
 outdim(f::Whitening) = size(f.W, 2)

--- a/test/cca.jl
+++ b/test/cca.jl
@@ -62,9 +62,15 @@ ym = vec(mean(Y, 2))
 Zx = X .- xm
 Zy = Y .- ym
 
-Cxx = cov(X; vardim=2)
-Cyy = cov(Y; vardim=2)
-Cxy = cov(X, Y; vardim=2)
+if VERSION < v"0.5.0-dev+660"
+    Cxx = cov(X; vardim=2)
+    Cyy = cov(Y; vardim=2)
+    Cxy = cov(X, Y; vardim=2)
+else
+    Cxx = cov(X, 2)
+    Cyy = cov(Y, 2)
+    Cxy = cov(X, Y, 2)
+end
 Cyx = Cxy'
 
 ## ccacov

--- a/test/ica.jl
+++ b/test/ica.jl
@@ -45,7 +45,11 @@ A = randn(m, k)
 X = A * S
 mv = vec(mean(X,2))
 @assert size(X) == (m, n)
-C = cov(X; vardim=2)
+if VERSION < v"0.5.0-dev+660"
+    C = cov(X; vardim=2)
+else
+    C = cov(X, 2)
+end
 
 # FastICA
 

--- a/test/lda.jl
+++ b/test/lda.jl
@@ -41,8 +41,13 @@ Xn = scale([2.8, 1.8], randn(2, n)) .+ [-5.0, 2.0]
 
 up = vec(mean(Xp, 2))
 un = vec(mean(Xn, 2))
-Cp = cov(Xp; vardim=2)
-Cn = cov(Xn; vardim=2)
+if VERSION < v"0.5.0-dev+660"
+    Cp = cov(Xp; vardim=2)
+    Cn = cov(Xn; vardim=2)
+else
+    Cp = cov(Xp, 2)
+    Cn = cov(Xn, 2)
+end
 C = 0.5 * (Cp + Cn)
 
 w_gt = C \ (up - un)

--- a/test/lreg.jl
+++ b/test/lreg.jl
@@ -44,7 +44,7 @@ a = llsq(Xt, y0; trans=true, bias=false)
 Aa = llsq(X, Y1; trans=false, bias=true)
 Aa_r = copy(Aa)
 @test size(Aa) == (n+1, n2)
-A, b = Aa[1:end-1,:], Aa[end,:]
+A, b = Aa[1:end-1,:], Aa[end:end,:]
 @test_approx_eq X' * (Y1 .- b) X'X * A
 
 aa = llsq(X, y1; trans=false, bias=true)
@@ -81,7 +81,7 @@ a = ridge(Xt, y0, r; trans=true, bias=false)
 Aa = ridge(X, Y1, r; trans=false, bias=true)
 Aa_r = copy(Aa)
 @test size(Aa) == (n+1, n2)
-A, b = Aa[1:end-1,:], Aa[end,:]
+A, b = Aa[1:end-1,:], Aa[end:end,:]
 @test_approx_eq X' * (Y1 .- b) (X'X + r * eye(n)) * A
 
 aa = ridge(X, y1, r; trans=false, bias=true)
@@ -118,7 +118,7 @@ a = ridge(Xt, y0, r; trans=true, bias=false)
 Aa = ridge(X, Y1, r; trans=false, bias=true)
 Aa_r = copy(Aa)
 @test size(Aa) == (n+1, n2)
-A, b = Aa[1:end-1,:], Aa[end,:]
+A, b = Aa[1:end-1,:], Aa[end:end,:]
 @test_approx_eq X' * (Y1 .- b) (X'X + diagm(r)) * A
 
 aa = ridge(X, y1, r; trans=false, bias=true)
@@ -156,7 +156,7 @@ a = ridge(Xt, y0, r; trans=true, bias=false)
 Aa = ridge(X, Y1, r; trans=false, bias=true)
 Aa_r = copy(Aa)
 @test size(Aa) == (n+1, n2)
-A, b = Aa[1:end-1,:], Aa[end,:]
+A, b = Aa[1:end-1,:], Aa[end:end,:]
 @test_approx_eq X' * (Y1 .- b) (X'X + r) * A
 
 aa = ridge(X, y1, r; trans=false, bias=true)

--- a/test/pca.jl
+++ b/test/pca.jl
@@ -66,7 +66,11 @@ X = R'randn(5, n) .+ randn(5)
 mv = vec(mean(X, 2))
 Z = X .- mv
 
-C = cov(X; vardim=2)
+if VERSION < v"0.5.0-dev+660"
+    C = cov(X; vardim=2)
+else
+    C = cov(X, 2)
+end
 pvs0 = sort(eigvals(C); rev=true)
 tv = sum(diag(C))
 

--- a/test/whiten.jl
+++ b/test/whiten.jl
@@ -10,7 +10,11 @@ n = 5
 
 X = rand(d, n)
 mv = vec(mean(X, 2))
-C = cov(X; vardim=2)
+if VERSION < v"0.5.0-dev+660"
+    C = cov(X; vardim=2)
+else
+    C = cov(X, 2)
+end
 C0 = copy(C)
 
 emax = maximum(eigvals(C))


### PR DESCRIPTION
Use `Compat.LinAlg.checksquare`. This should make the package work again on 0.5.