### PR TITLE
Add high-dimensional LDA algorithm; fix julia-0.5 depwarns/errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.3
     - 0.4
     - nightly
 notifications:
@@ -13,4 +12,3 @@ script:
     - julia -e 'Pkg.clone(pwd()); Pkg.build("MultivariateStats"); Pkg.test("MultivariateStats"; coverage=true)';
 after_success:
     - julia -e 'cd(Pkg.dir("MultivariateStats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ julia:
     - nightly
 notifications:
     email: false
-script:
-    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.build("MultivariateStats"); Pkg.test("MultivariateStats"; coverage=true)';
+# script:
+#     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#     - julia -e 'Pkg.clone(pwd()); Pkg.build("MultivariateStats"); Pkg.test("MultivariateStats"; coverage=true)';
 after_success:
     - julia -e 'cd(Pkg.dir("MultivariateStats")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.4
-Compat 0.7.12
-ArrayViews 0.5.0
+Compat 0.8.4
 StatsBase 0.7.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 Compat 0.7.12
 ArrayViews 0.5.0
 StatsBase 0.7.0

--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -74,6 +74,7 @@ module MultivariateStats
     LinearDiscriminant,     # Type: Linear Discriminant functional
     MulticlassLDAStats,     # Type: Statistics required for training multi-class LDA
     MulticlassLDA,          # Type: Multi-class LDA model
+    SubspaceLDA,            # Type: LDA model for high-dimensional spaces
 
     ldacov,                 # Linear discriminant analysis based on covariances
 

--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -1,11 +1,11 @@
 module MultivariateStats
     using Compat
     using StatsBase
-    using ArrayViews
 
     import Base: length, size, show, dump, sumabs2
     import Base.LinAlg: Cholesky
     import StatsBase: fit, predict
+    using  Compat: view
 
     export
 

--- a/test/cca.jl
+++ b/test/cca.jl
@@ -89,8 +89,8 @@ rho = correlations(M)
 
 @test_approx_eq Px' * Cxx * Px eye(p)
 @test_approx_eq Py' * Cyy * Py eye(p)
-@test_approx_eq Cxy * (Cyy \ Cyx) * Px scale(Cxx * Px, rho.^2)
-@test_approx_eq Cyx * (Cxx \ Cxy) * Py scale(Cyy * Py, rho.^2)
+@test_approx_eq Cxy * (Cyy \ Cyx) * Px  Cxx * Px * Diagonal(rho.^2)
+@test_approx_eq Cyx * (Cxx \ Cxy) * Py  Cyy * Py * Diagonal(rho.^2)
 @test_approx_eq Px qnormalize!(Cxx \ (Cxy * Py), Cxx)
 @test_approx_eq Py qnormalize!(Cyy \ (Cyx * Px), Cyy)
 
@@ -108,8 +108,8 @@ rho = correlations(M)
 
 @test_approx_eq Px' * Cxx * Px eye(p)
 @test_approx_eq Py' * Cyy * Py eye(p)
-@test_approx_eq Cxy * (Cyy \ Cyx) * Px scale(Cxx * Px, rho.^2)
-@test_approx_eq Cyx * (Cxx \ Cxy) * Py scale(Cyy * Py, rho.^2)
+@test_approx_eq Cxy * (Cyy \ Cyx) * Px  Cxx * Px * Diagonal(rho.^2)
+@test_approx_eq Cyx * (Cxx \ Cxy) * Py  Cyy * Py * Diagonal(rho.^2)
 @test_approx_eq Px qnormalize!(Cxx \ (Cxy * Py), Cxx)
 @test_approx_eq Py qnormalize!(Cyy \ (Cyx * Px), Cyy)
 
@@ -130,8 +130,7 @@ rho = correlations(M)
 
 @test_approx_eq Px' * Cxx * Px eye(p)
 @test_approx_eq Py' * Cyy * Py eye(p)
-@test_approx_eq Cxy * (Cyy \ Cyx) * Px scale(Cxx * Px, rho.^2)
-@test_approx_eq Cyx * (Cxx \ Cxy) * Py scale(Cyy * Py, rho.^2)
+@test_approx_eq Cxy * (Cyy \ Cyx) * Px  Cxx * Px * Diagonal(rho.^2)
+@test_approx_eq Cyx * (Cxx \ Cxy) * Py  Cyy * Py * Diagonal(rho.^2)
 @test_approx_eq Px qnormalize!(Cxx \ (Cxy * Py), Cxx)
 @test_approx_eq Py qnormalize!(Cyy \ (Cyx * Px), Cyy)
-

--- a/test/cmds.jl
+++ b/test/cmds.jl
@@ -1,5 +1,6 @@
 using MultivariateStats
 using Base.Test
+using Compat
 
 ## testing data
 
@@ -16,15 +17,15 @@ D0 = pwdists(X0)
 
 ## conversion between dmat and gram
 
-@assert issym(D0)
-@assert issym(G0)
+@assert issymmetric(D0)
+@assert issymmetric(G0)
 
 D = gram2dmat(G0)
-@test issym(D)
+@test issymmetric(D)
 @test_approx_eq D D0
 
 G = dmat2gram(D0)
-@test issym(G)
+@test issymmetric(G)
 @test_approx_eq gram2dmat(G) D0
 
 ## classical MDS

--- a/test/lda.jl
+++ b/test/lda.jl
@@ -36,8 +36,8 @@ R1 = [cos(t1) -sin(t1); sin(t1) cos(t1)]
 R2 = [cos(t2) -sin(t2); sin(t2) cos(t2)]
 
 n = 20
-Xp = scale([1.2, 3.6], randn(2, n)) .+ [1.0, -3.0]
-Xn = scale([2.8, 1.8], randn(2, n)) .+ [-5.0, 2.0]
+Xp = Diagonal([1.2, 3.6]) * randn(2, n) .+ [1.0, -3.0]
+Xn = Diagonal([2.8, 1.8]) * randn(2, n) .+ [-5.0, 2.0]
 
 up = vec(mean(Xp, 2))
 un = vec(mean(Xn, 2))
@@ -70,4 +70,3 @@ f = ldacov(Cp, Cn, up, un)
 f = fit(LinearDiscriminant, Xp, Xn)
 @test_approx_eq f.w w_gt
 @test_approx_eq f.b b_gt
-

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -1,6 +1,10 @@
 using MultivariateStats
 using Base.Test
 
+if !isdefined(Base, :normalize)
+    normalize(x) = x/norm(x)
+end
+
 #Test equivalence of eigenvectors/singular vectors taking into account possible
 #phase (sign) differences
 #This may end up in Base.Test; see JuliaLang/julia#10651
@@ -35,7 +39,7 @@ for k = 1:nc
 	R = qr(randn(d, d))[1]
 	nk = ns[k]
 
-	Xk = R * scale(2 * rand(d) + 0.5, randn(d, nk)) .+ randn(d)
+	Xk = R * Diagonal(2 * rand(d) + 0.5) * randn(d, nk) .+ randn(d)
 	yk = fill(k, nk)
 	uk = vec(mean(Xk, 2))
 	Zk = Xk .- uk
@@ -97,7 +101,7 @@ U = Sb * P1
 V = Sw_r * P1
 # test whether U is proportional to V,
 # which indicates P is the generalized eigenvectors
-@test_approx_eq U scale(V, vec(mean(U ./ V, 1)))
+@test_approx_eq U V*Diagonal(vec(mean(U./V, 1)))
 
 P2 = mclda_solve(Sb, Sw, :whiten, nc-1, lambda)
 @test_approx_eq P2' * Sw_r * P2 eye(nc-1)

--- a/test/pca.jl
+++ b/test/pca.jl
@@ -84,7 +84,7 @@ pvs = principalvars(M)
 @test outdim(M) == 5
 @test mean(M) == mv
 @test_approx_eq P'P eye(5)
-@test_approx_eq C * P scale(P, pvs)
+@test_approx_eq C*P P*Diagonal(pvs)
 @test issorted(pvs; rev=true)
 @test_approx_eq pvs pvs0
 @test_approx_eq tvar(M) tv
@@ -122,7 +122,7 @@ pvs = principalvars(M)
 @test outdim(M) == 5
 @test mean(M) == mv
 @test_approx_eq P'P eye(5)
-@test_approx_eq_eps C * P scale(P, pvs) 1.0e-3
+@test_approx_eq_eps C*P P*Diagonal(pvs) 1.0e-3
 @test issorted(pvs; rev=true)
 @test_approx_eq_eps pvs pvs0 1.0e-3
 @test_approx_eq_eps tvar(M) tv 1.0e-3


### PR DESCRIPTION
The current multicomponent LDA algorithm stores the scatter (covariance) matrices, which in `d` dimensions is a `d-by-d` matrix. When `d` gets big (e.g., of order 10^6), this is bad news. This PR adds an alternative implementation of LDA that does not require storage of the scatter matrices. It also features regularization by projecting down to the subspace spanned by the within-class scatter, and consequently does not require "extra" regularization.

Moreover, this fixes errors due to Base now exporting `view`, and depwarns from `scale` and `issymmetric`. One note of caution: Compat now defines `view` as an alias for `slice`, and on julia-0.3 `slice` was slow compared to `ArrayViews`. So this could cause a pretty serious performance hit for julia-0.3 users. Perhaps we should bump the minimum julia version to 0.4 before merging this?
