### PR TITLE
Add a normalization option to SubspaceLDA

### DIFF
--- a/docs/source/mclda.rst
+++ b/docs/source/mclda.rst
@@ -8,11 +8,11 @@ Multi-class Linear Discriminant Analysis
 Overview
 ~~~~~~~~~~
 
-*Multi-class LDA* is based on the analysis of two scatter matrices: *with-class scatter matrix* and *between-class scatter matrix*.
+*Multi-class LDA* is based on the analysis of two scatter matrices: *within-class scatter matrix* and *between-class scatter matrix*.
 
 Given a set of samples :math:`\mathbf{x}_1, \ldots, \mathbf{x}_n`, and their class labels :math:`y_1, \ldots, y_n`:
 
-The **with-class scatter matrix** is defined as:
+The **within-class scatter matrix** is defined as:
 
 .. math::
 
@@ -43,8 +43,29 @@ The solution is given by the following generalized eigenvalue problem:
 Generally, at most ``m - 1`` generalized eigenvectors are useful to discriminate between ``m`` classes.
 
 When the dimensionality is high, it may not be feasible to construct
-the scatter matrices. In such cases, see SubspaceLDA_ below.
+the scatter matrices explicitly. In such cases, see SubspaceLDA_ below.
 
+Normalization by number of observations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+An alternative definition of the within- and between-class scatter
+matrices normalizes for the number of observations in each group:
+
+.. math::
+
+    \mathbf{S}_w^* &= n \sum_{k=1}^m \frac{1}{n_k} \sum_{i \mid y_i=k} (\mathbf{x}_i - \boldsymbol{\mu}_{k}) (\mathbf{x}_i - \boldsymbol{\mu}_{k})^T
+
+    \mathbf{S}_b^* &= n \sum_{k=1}^m (\boldsymbol{\mu}_k - \boldsymbol{\mu}^*) (\boldsymbol{\mu}_k - \boldsymbol{\mu}^*)^T
+
+where
+
+.. math::
+
+    \boldsymbol{\mu}^* = \frac{1}{k} \sum_{k=1}^m \boldsymbol{\mu}_k.
+
+This definition can sometimes be more useful when looking for
+directions which discriminate among clusters containing widely-varying
+numbers of observations.
 
 Multi-class LDA
 ~~~~~~~~~~~~~~~~~
@@ -144,6 +165,7 @@ One can use ``fit`` to perform multi-class LDA over a set of data:
 
     Here, :math:`\kappa` equals ``regcoef * eigmax(Sw)``. The columns of ``P`` are arranged in descending order of the corresponding generalized eigenvalues.
 
+    Note that ``MulticlassLDA`` does not currently support the normalized version using :math:`\mathbf{S}_w^*` and :math:`\mathbf{S}_b^*` (see ``SubspaceLDA`` below).
 
 Task Functions
 ~~~~~~~~~~~~~~~
@@ -255,3 +277,11 @@ the equation
 When ``P`` is of full rank (e.g., if there are more data points than
 dimensions), then this equation guarantees that
 Eq. :eq:`LDAeigenvalue` will also hold.
+
+SubspaceLDA also supports the normalized version of LDA via the ``normalize`` keyword:
+
+.. code-block:: julia
+
+   M = fit(SubspaceLDA, X, label; normalize=true)
+
+would perform LDA using the equivalent of :math:`\mathbf{S}_w^*` and :math:`\mathbf{S}_b^*`.

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -130,40 +130,55 @@ M = fit(MulticlassLDA, nc, X, y; method=:whiten, regcoef=lambda)
 
 # Low-dimensional case (no singularities)
 
-dX = randn(5,1500);
-# 3 groups of 500 with zero mean
-for i = 0:500:1000
-    dX[:,(1:500)+i] = dX[:,(1:500)+i] .- mean(dX[:,(1:500)+i],2)
-end
 centers = [zeros(5) [10.0;zeros(4)] [0.0;10.0;zeros(3)]]
-X = [dX[:,1:500].+centers[:,1] dX[:,501:1000].+centers[:,2] dX[:,1001:1500].+centers[:,3]]
-label = [fill(1,500); fill(2,500); fill(3,500)]
-M = fit(SubspaceLDA, X, label)
-@test indim(M) == 5
-@test outdim(M) == 2
-@test_approx_eq mean(M) vec(mean(centers,2))
-@test_approx_eq classmeans(M) centers
-@test classweights(M) == [500,500,500]
-x = rand(5)
-@test_approx_eq transform(M, x) projection(M)'*x
-dcenters = centers .- mean(centers,2)
-Hb = dcenters*sqrt(500)
-Sb = Hb*Hb'
-Sw = dX*dX'
-# When there are no singularities, we need to solve the "regular" LDA eigenvalue equation
-proj = projection(M)
-@test_approx_eq Sb*proj Sw*proj*Diagonal(M.λ)
-@test_approx_eq proj'*Sw*proj eye(2,2)
 
-# also check that this is consistent with the conventional algorithm
-Mld = fit(MulticlassLDA, 3, X, label)
-for i = 1:2
-    @test_approx_eq abs(dot(normalize(proj[:,i]), normalize(Mld.proj[:,i]))) 1
+# Case 1: 3 groups of 500
+dX = randn(5,1500);
+for i = 0:500:1000
+    dX[:,(1:500)+i] = dX[:,(1:500)+i] .- mean(dX[:,(1:500)+i],2)  # make the mean of each 0
+end
+dX1 = dX
+X1 = [dX[:,1:500].+centers[:,1] dX[:,501:1000].+centers[:,2] dX[:,1001:1500].+centers[:,3]]
+label1 = [fill(1,500); fill(2,500); fill(3,500)]
+# Case 2: 3 groups, one with 1000, one with 100, and one with 10
+dX = randn(5,1110);
+dX[:,   1:1000] = dX[:,   1:1000] .- mean(dX[:,   1:1000],2)
+dX[:,1001:1100] = dX[:,1001:1100] .- mean(dX[:,1001:1100],2)
+dX[:,1101:1110] = dX[:,1101:1110] .- mean(dX[:,1101:1110],2)
+dX2 = dX
+X2 = [dX[:,1:1000].+centers[:,1] dX[:,1001:1100].+centers[:,2] dX[:,1101:1110].+centers[:,3]]
+label2 = [fill(1,1000); fill(2,100); fill(3,10)]
+
+for (X, dX, label) in ((X1, dX1, label1), (X2, dX2, label2))
+    w = [length(find(label.==1)), length(find(label.==2)), length(find(label.==3))]
+    M = fit(SubspaceLDA, X, label)
+    @test indim(M) == 5
+    @test outdim(M) == 2
+    totcenter = vec(sum(centers.*w',2)./sum(w))
+    @test_approx_eq mean(M) totcenter
+    @test_approx_eq classmeans(M) centers
+    @test classweights(M) == w
+    x = rand(5)
+    @test_approx_eq transform(M, x) projection(M)'*x
+    dcenters = centers .- totcenter
+    Hb = dcenters.*sqrt(w)'
+    Sb = Hb*Hb'
+    Sw = dX*dX'
+    # When there are no singularities, we need to solve the "regular" LDA eigenvalue equation
+    proj = projection(M)
+    @test_approx_eq Sb*proj Sw*proj*Diagonal(M.λ)
+    @test_approx_eq proj'*Sw*proj eye(2,2)
+
+    # also check that this is consistent with the conventional algorithm
+    Mld = fit(MulticlassLDA, 3, X, label)
+    for i = 1:2
+        @test_approx_eq abs(dot(normalize(proj[:,i]), normalize(Mld.proj[:,i]))) 1
+    end
 end
 
 # High-dimensional case (undersampled => singularities)
 X = randn(10^6, 9)
-label = rand(1:3, 9)
+label = rand(1:3, 9); label[1:3] = 1:3
 M = fit(SubspaceLDA, X, label)
 centers = M.cmeans
 for i = 1:3
@@ -187,3 +202,27 @@ dcenters = centers .- mean(X, 2)
 Hb = dcenters*Diagonal(sqrt(M.cweights))
 Hw = X - centers[:,label]
 @test_approx_eq (M.projw'*Hb)*(Hb'*M.projw)*M.projLDA (M.projw'*Hw)*(Hw'*M.projw)*M.projLDA*Diagonal(M.λ)
+
+# Test normalized LDA
+function gen_ldadata_2(centers, n1, n2)
+    d = size(centers, 1)
+    X = randn(d, n1+n2)
+    X[:,1:n1]       .-= vec(mean(X[:,1:n1],2))
+    X[:,n1+1:n1+n2] .-= vec(mean(X[:,n1+1:n1+n2],2))
+    dX = copy(X)
+    X[:,1:n1]       .+= centers[:,1]
+    X[:,n1+1:n1+n2] .+= centers[:,2]
+    label = [fill(1,n1); fill(2,n2)]
+    X, dX, label
+end
+centers = zeros(2,2); centers[1,2] = 10
+n1 = 100
+for n2 in (100, 1000, 10000)
+    X, dX, label = gen_ldadata_2(centers, n1, n2)
+    M = fit(SubspaceLDA, X, label; normalize=true)
+    proj = projection(M)
+    Hb = centers .- mean(centers, 2)   # not weighted by number in each cluster
+    Sb = Hb*Hb'
+    Sw = dX*dX'/(n1+n2)
+    @test_approx_eq Sb*proj Sw*proj*Diagonal(M.λ)
+end


### PR DESCRIPTION
If you're performing LDA on data sets in which the number of points per class varies widely, the definition of the within- and between-class scatter matrices used in this package is dominated by the classes with the most points; a small cluster might have negligible impact on the final choice of directions. In many applications, this is undesirable. There is [a self-consistent alternative definition](http://stats.stackexchange.com/questions/123490/what-is-the-correct-formula-for-between-class-scatter-matrix-in-lda) of LDA which normalizes for the number of points per class. This implements normalization *as an option* for the `SubspaceLDA` formulation.

Note that once we get this through the review process and merge it, someone needs to push an update to the documentation.
