### PR TITLE
Added Convergence Exceptions for PPCA (EM & Bayes methods) & ICA (fastica!)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.17.0
-StatsBase 0.7.0
+StatsBase 0.12.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 Compat 0.17.0
-StatsBase 0.12.0
+StatsBase 0.19.0

--- a/src/ica.jl
+++ b/src/ica.jl
@@ -144,7 +144,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
             @printf("Iter %4d:  change = %.6e\n", t, chg)
         end
     end
-    converged || throw(ConvergenceException(maxiter, chg, Float64(tol)))
+    converged || throw(ConvergenceException(maxiter, chg, oftype(chg, tol)))
     return W
 end
 

--- a/src/ica.jl
+++ b/src/ica.jl
@@ -60,7 +60,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
                   X::DenseMatrix{Float64},      # (whitened) observation sample matrix, size(m, n)
                   fun::ICAGDeriv,               # approximate neg-entropy functor
                   maxiter::Int,                 # maximum number of iterations
-                  tol::Float64,                    # convergence tolerance
+                  tol::Real,                    # convergence tolerance
                   verbose::Bool)                # whether to show iterative info
 
     # argument checking
@@ -88,7 +88,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
     end
 
     # main loop
-    chg = 0.0
+    chg = NaN
     t = 0
     converged = false
     while !converged && t < maxiter
@@ -144,7 +144,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
             @printf("Iter %4d:  change = %.6e\n", t, chg)
         end
     end
-    converged || throw(ConvergenceException(maxiter, chg, tol))
+    converged || throw(ConvergenceException(maxiter, chg, Float64(tol)))
     return W
 end
 
@@ -156,7 +156,7 @@ function fit(::Type{ICA}, X::DenseMatrix{Float64},          # sample matrix, siz
                           fun::ICAGDeriv=icagfun(:tanh),    # approx neg-entropy functor
                           do_whiten::Bool=true,             # whether to perform pre-whitening 
                           maxiter::Integer=100,             # maximum number of iterations
-                          tol::Float64=1.0e-6,                 # convergence tolerance
+                          tol::Real=1.0e-6,                 # convergence tolerance
                           mean=nothing,                     # pre-computed mean
                           winit::Matrix{Float64}=zeros(0,0),  # init guess of W, size (m, k)
                           verbose::Bool=false)              # whether to display iterations

--- a/src/ica.jl
+++ b/src/ica.jl
@@ -60,7 +60,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
                   X::DenseMatrix{Float64},      # (whitened) observation sample matrix, size(m, n)
                   fun::ICAGDeriv,               # approximate neg-entropy functor
                   maxiter::Int,                 # maximum number of iterations
-                  tol::Real,                    # convergence tolerance
+                  tol::Float64,                    # convergence tolerance
                   verbose::Bool)                # whether to show iterative info
 
     # argument checking
@@ -88,6 +88,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
     end
 
     # main loop
+    chg = 0.0
     t = 0
     converged = false
     while !converged && t < maxiter
@@ -143,7 +144,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
             @printf("Iter %4d:  change = %.6e\n", t, chg)
         end
     end
-    converged || throw(ConvergenceException(maxiter))
+    converged || throw(ConvergenceException(maxiter, chg, tol))
     return W
 end
 
@@ -155,7 +156,7 @@ function fit(::Type{ICA}, X::DenseMatrix{Float64},          # sample matrix, siz
                           fun::ICAGDeriv=icagfun(:tanh),    # approx neg-entropy functor
                           do_whiten::Bool=true,             # whether to perform pre-whitening 
                           maxiter::Integer=100,             # maximum number of iterations
-                          tol::Real=1.0e-6,                 # convergence tolerance
+                          tol::Float64=1.0e-6,                 # convergence tolerance
                           mean=nothing,                     # pre-computed mean
                           winit::Matrix{Float64}=zeros(0,0),  # init guess of W, size (m, k)
                           verbose::Bool=false)              # whether to display iterations
@@ -196,4 +197,3 @@ function fit(::Type{ICA}, X::DenseMatrix{Float64},          # sample matrix, siz
     end
     return ICA(mv, W)
 end
-

--- a/src/ica.jl
+++ b/src/ica.jl
@@ -143,6 +143,7 @@ function fastica!(W::DenseMatrix{Float64},      # initialized component matrix, 
             @printf("Iter %4d:  change = %.6e\n", t, chg)
         end
     end
+    converged || throw(ConvergenceException(maxiter))
     return W
 end
 

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -86,7 +86,7 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
     σ² = 0.
     M⁻¹ = inv(W'W .+ σ²*eye(q))
 
-    i = 0
+    i = 1
     L_old = 0.
     chg = NaN
     converged = false
@@ -133,7 +133,7 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
     M⁻¹ = inv(M)
     α = zeros(q)
 
-    i = 0
+    i = 1
     chg = NaN
     L_old = 0.
     converged = false

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -88,6 +88,7 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
 
     i = 1
     L_old = 0.
+    converged = false
     while i < tot
         # EM-steps
         SW = S*W
@@ -103,11 +104,13 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L = (-n/2)*(log(det(C)) + trace(C⁻¹*S))  # (-n/2)*d*log(2π) omitted
         # println("$i] ΔL: $(abs(L_old - L)), L: $L")
         if abs(L_old - L) < tol
+            converged = true
             break
         end
         L_old = L
         i += 1
     end
+    converged || throw(ConvergenceException(tot))
 
     return PPCA(mean, W, σ²)
 end
@@ -130,6 +133,7 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
 
     i = 1
     L_old = 0.
+    converged = false
     while i < tot
         # EM-steps
         SW = S*W
@@ -150,11 +154,13 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L = (-n/2)*(log(det(C)) + trace(C⁻¹*S))  # (-n/2)*d*log(2π) omitted
         # println("$i] ΔL: $(abs(L_old - L)), L: $L")
         if abs(L_old - L) < tol
+            converged = true
             break
         end
         L_old = L
         i += 1
     end
+    converged || throw(ConvergenceException(tot))
 
     return PPCA(mean, W[:,wnorm .> 0.], σ²)
 end

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -86,7 +86,7 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
     σ² = 0.
     M⁻¹ = inv(W'W .+ σ²*eye(q))
 
-    i = 0 
+    i = 0
     L_old = 0.
     chg = NaN
     converged = false
@@ -133,7 +133,7 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
     M⁻¹ = inv(M)
     α = zeros(q)
 
-    i = 0 
+    i = 0
     chg = NaN
     L_old = 0.
     converged = false

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -112,7 +112,7 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L_old = L
         i += 1
     end
-    converged || throw(ConvergenceException(tot, chg, tol))
+    converged || throw(ConvergenceException(tot, chg, oftype(chg,tol)))
 
     return PPCA(mean, W, σ²)
 end
@@ -164,7 +164,7 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L_old = L
         i += 1
     end
-    converged || throw(ConvergenceException(tot, chg, Float64(tol)))
+    converged || throw(ConvergenceException(tot, chg, oftype(chg, tol)))
 
     return PPCA(mean, W[:,wnorm .> 0.], σ²)
 end

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -43,7 +43,7 @@ end
 
 function ppcaml{T<:AbstractFloat}(Z::DenseMatrix{T}, mean::Vector{T};
                 maxoutdim::Int=size(Z,1)-1,
-                tol::Float64=1.0e-6) # convergence tolerance
+                tol::Real=1.0e-6) # convergence tolerance
 
     check_pcaparams(size(Z,1), mean, maxoutdim, 1.)
 
@@ -75,7 +75,7 @@ end
 
 function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
                 maxoutdim::Int=size(S,1)-1,
-                tol::Float64=1.0e-6,   # convergence tolerance
+                tol::Real=1.0e-6,   # convergence tolerance
                 tot::Integer=1000)  # maximum number of iterations
 
     check_pcaparams(size(S,1), mean, maxoutdim, 1.)
@@ -119,7 +119,7 @@ end
 
 function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
                  maxoutdim::Int=size(S,1)-1,
-                 tol::Float64=1.0e-6,   # convergence tolerance
+                 tol::Real=1.0e-6,   # convergence tolerance
                  tot::Integer=1000)  # maximum number of iterations
 
     check_pcaparams(size(S,1), mean, maxoutdim, 1.)
@@ -164,7 +164,7 @@ function bayespca{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L_old = L
         i += 1
     end
-    converged || throw(ConvergenceException(tot,chg,tol))
+    converged || throw(ConvergenceException(tot, chg, Float64(tol)))
 
     return PPCA(mean, W[:,wnorm .> 0.], σ²)
 end
@@ -175,7 +175,7 @@ function fit{T<:AbstractFloat}(::Type{PPCA}, X::DenseMatrix{T};
              method::Symbol=:ml,
              maxoutdim::Int=size(X,1)-1,
              mean=nothing,
-             tol::Float64=1.0e-6,   # convergence tolerance
+             tol::Real=1.0e-6,   # convergence tolerance
              tot::Integer=1000)  # maximum number of iterations
 
     d, n = size(X)

--- a/src/ppca.jl
+++ b/src/ppca.jl
@@ -112,7 +112,7 @@ function ppcaem{T<:AbstractFloat}(S::DenseMatrix{T}, mean::Vector{T}, n::Int;
         L_old = L
         i += 1
     end
-    converged || throw(ConvergenceException(tot, chg, oftype(chg,tol)))
+    converged || throw(ConvergenceException(tot, chg, oftype(chg, tol)))
 
     return PPCA(mean, W, σ²)
 end

--- a/test/ica.jl
+++ b/test/ica.jl
@@ -67,4 +67,4 @@ M = fit(ICA, X, k; do_whiten=true, tol=Inf)
 W = M.W
 @test W'C * W ≈ eye(k)
 
-@test_throws StatsBase.ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1)
+@test_throws StatsBase.ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1.)

--- a/test/ica.jl
+++ b/test/ica.jl
@@ -1,5 +1,6 @@
 using MultivariateStats
 using Base.Test
+import StatsBase
 
 srand(15678)
 
@@ -49,7 +50,7 @@ C = cov(X, 2)
 
 # FastICA
 
-M = fit(ICA, X, k; do_whiten=false)
+M = fit(ICA, X, k; do_whiten=false, tol=Inf)
 @test isa(M, ICA)
 @test indim(M) == m
 @test outdim(M) == k
@@ -58,7 +59,7 @@ W = M.W
 @test transform(M, X) ≈ W' * (X .- mv)
 @test W'W ≈ eye(k)
 
-M = fit(ICA, X, k; do_whiten=true)
+M = fit(ICA, X, k; do_whiten=true, tol=Inf)
 @test isa(M, ICA)
 @test indim(M) == m
 @test outdim(M) == k
@@ -66,3 +67,4 @@ M = fit(ICA, X, k; do_whiten=true)
 W = M.W
 @test W'C * W ≈ eye(k)
 
+@test_throws StatsBase.ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1)

--- a/test/ica.jl
+++ b/test/ica.jl
@@ -67,4 +67,4 @@ M = fit(ICA, X, k; do_whiten=true, tol=Inf)
 W = M.W
 @test W'C * W ≈ eye(k)
 
-@test_throws StatsBase.ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1.)
+@test_throws StatsBase.ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1)

--- a/test/ppca.jl
+++ b/test/ppca.jl
@@ -1,5 +1,6 @@
 using MultivariateStats
 using Base.Test
+import StatsBase
 
 srand(34568)
 
@@ -111,6 +112,8 @@ P = projection(M)
 @test outdim(M) == 3
 @test P'P ≈ eye(3)
 
+@test_throws StatsBase.ConvergenceException fit(PPCA, X; method=:em, tot=1)
+
 # bayespca
 M0 = fit(PCA, X; mean=mv, maxoutdim = 3)
 
@@ -136,6 +139,8 @@ P = projection(M)
 @test indim(M) == 5
 @test outdim(M) == 2
 @test P'P ≈ eye(2)
+
+@test_throws StatsBase.ConvergenceException fit(PPCA, X; method=:bayes, tot=1)
 
 # test that fit works with Float32 values
 X2 = convert(Array{Float32,2}, X)


### PR DESCRIPTION
See #36 

Todo
- [x] add ConvergenceExceptions to ICA & PPCA methods

- [x] ~correct the calculation of the change in model for fastica!~ Seperate PR.

- [x] ~add option to turn off convergence exceptions~ (can just put tol=Inf)

- [X] add extra field to exception (in statsbase) to see how close to convergence the algorithm was

- [X] (pending travis) Add lastchange to exceptions now that statsbase is update as above (commit: https://github.com/JuliaStats/StatsBase.jl/commit/4d03581f94921bed1c2b4744d18ccc71f2f0d216)

