### PR TITLE
make CCA type parametric

### DIFF
--- a/src/cca.jl
+++ b/src/cca.jl
@@ -189,8 +189,8 @@ function _ccasvd(Zx, Zy, xmean, ymean, p::Int)
     # compute Px and Py
     ord = sortperm(S.S; rev=true)
     si = ord[1:p]
-    Px = scale!(Sx.U, 1.0 ./ Sx.S) * S.U[:, si]
-    Py = A_mul_Bt(scale!(Sy.U, 1.0 ./ Sy.S), S.Vt[si, :])
+    Px = scale!(Sx.U, inv.(Sx.S)) * S.U[:, si]
+    Py = A_mul_Bt(scale!(Sy.U, inv.(Sy.S)), S.Vt[si, :])
 
     # scale so that Px' * Cxx * Py == I 
     #           and Py' * Cyy * Py == I, 
@@ -215,7 +215,6 @@ function fit(::Type{CCA{<:Real}}, X::DenseMatrix{<:Real}, Y::DenseMatrix{<:Real}
              method::Symbol=:svd, 
              xmean=nothing, 
              ymean=nothing)
-
     dx, n = size(X)
     dy, n2 = size(Y)
 

--- a/src/cca.jl
+++ b/src/cca.jl
@@ -2,18 +2,18 @@
 
 #### CCA Type
 
-type CCA
-    xmean::Vector{Float64}  # sample mean of X: of length dx (can be empty)
-    ymean::Vector{Float64}  # sample mean of Y: of length dy (can be empty)  
-    xproj::Matrix{Float64}  # projection matrix for X, of size (dx, p)
-    yproj::Matrix{Float64}  # projection matrix for Y, of size (dy, p)
-    corrs::Vector{Float64}  # correlations, of length p
+type CCA{T<:Real}
+    xmean::Vector{T}  # sample mean of X: of length dx (can be empty)
+    ymean::Vector{T}  # sample mean of Y: of length dy (can be empty)  
+    xproj::Matrix{T}  # projection matrix for X, of size (dx, p)
+    yproj::Matrix{T}  # projection matrix for Y, of size (dy, p)
+    corrs::Vector{T}  # correlations, of length p
 
-    function CCA(xm::Vector{Float64}, 
-                 ym::Vector{Float64}, 
-                 xp::Matrix{Float64},
-                 yp::Matrix{Float64}, 
-                 crs::Vector{Float64})
+    function CCA(xm::Vector{T}, 
+                 ym::Vector{T}, 
+                 xp::Matrix{T},
+                 yp::Matrix{T}, 
+                 crs::Vector{T}) where T <:Real
 
         dx, px = size(xp)
         dy, py = size(yp)
@@ -30,7 +30,7 @@ type CCA
         length(crs) == px ||
             throw(DimensionMismatch("Incorrect length of corrs."))
 
-        new(xm, ym, xp, yp, crs)
+        new{T}(xm, ym, xp, yp, crs)
     end
 end
 
@@ -50,8 +50,8 @@ correlations(M::CCA) = M.corrs
 
 ## use
 
-xtransform{T<:Real}(M::CCA, X::AbstractVecOrMat{T}) = At_mul_B(M.xproj, centralize(X, M.xmean))
-ytransform{T<:Real}(M::CCA, Y::AbstractVecOrMat{T}) = At_mul_B(M.yproj, centralize(Y, M.ymean))
+xtransform(M::CCA, X::AbstractVecOrMat{<:Real}) = At_mul_B(M.xproj, centralize(X, M.xmean))
+ytransform(M::CCA, Y::AbstractVecOrMat{<:Real}) = At_mul_B(M.yproj, centralize(Y, M.ymean))
 
 ## show & dump
 
@@ -79,11 +79,11 @@ end
 
 ## ccacov
 
-function ccacov(Cxx::DenseMatrix{Float64}, 
-                Cyy::DenseMatrix{Float64},
-                Cxy::DenseMatrix{Float64}, 
-                xmean::Vector{Float64},
-                ymean::Vector{Float64},
+function ccacov(Cxx::DenseMatrix{<:Real}, 
+                Cyy::DenseMatrix{<:Real},
+                Cxy::DenseMatrix{<:Real}, 
+                xmean::Vector{<:Real},
+                ymean::Vector{<:Real},
                 p::Int)
 
     # argument checking
@@ -143,10 +143,10 @@ end
 
 ## ccasvd
 
-function ccasvd(Zx::DenseMatrix{Float64}, 
-                Zy::DenseMatrix{Float64}, 
-                xmean::Vector{Float64}, 
-                ymean::Vector{Float64}, 
+function ccasvd(Zx::DenseMatrix{<:Real}, 
+                Zy::DenseMatrix{<:Real}, 
+                xmean::Vector{<:Real}, 
+                ymean::Vector{<:Real}, 
                 p::Int)
 
     dx, n = size(Zx)
@@ -210,7 +210,7 @@ end
 
 ## interface functions
 
-function fit(::Type{CCA}, X::DenseMatrix{Float64}, Y::DenseMatrix{Float64};
+function fit(::Type{CCA{<:Real}}, X::DenseMatrix{<:Real}, Y::DenseMatrix{<:Real};
              outdim::Int=min(min(size(X)...), min(size(Y)...)),
              method::Symbol=:svd, 
              xmean=nothing, 

--- a/src/common.jl
+++ b/src/common.jl
@@ -22,7 +22,7 @@ decentralize(x::AbstractMatrix, m::AbstractVector) = (isempty(m) ? x : x .+ m)::
 
 fullmean{T}(d::Int, mv::Vector{T}) = (isempty(mv) ? zeros(T, d) : mv)::Vector{T} 
 
-preprocess_mean{T<:AbstractFloat}(X::Matrix{T}, m) = (m == nothing ? vec(Base.mean(X, 2)) :
+preprocess_mean{T<:Real}(X::Matrix{T}, m) = (m == nothing ? vec(Base.mean(X, 2)) :
                                                       m == 0 ? T[] : 
                                                       m)::Vector{T}
 

--- a/test/cca.jl
+++ b/test/cca.jl
@@ -9,45 +9,46 @@ dx = 5
 dy = 6
 p = 3
 
-# CCA with zero means
+for T in (Float16, Float64)
+    # CCA with zero means
 
-X = rand(dx, 100)
-Y = rand(dy, 100)
+    X = rand(T, (dx, 100))
+    Y = rand(T, (dy, 100))
 
-Px = qr(randn(dx, dx))[1][:, 1:p]
-Py = qr(randn(dy, dy))[1][:, 1:p]
+    Px = qr(randn(T, (dx, dx)))[1][:, 1:p]
+    Py = qr(randn(T, (dy, dy)))[1][:, 1:p]
 
-M = CCA(Float64[], Float64[], Px, Py, [0.8, 0.6, 0.4])
+    M = CCA(T[], T[], Px, Py, T[0.8, 0.6, 0.4])
 
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test xmean(M) == zeros(dx)
-@test ymean(M) == zeros(dy)
-@test xprojection(M) == Px
-@test yprojection(M) == Py
-@test correlations(M) == [0.8, 0.6, 0.4]
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test xmean(M) == zeros(dx)
+    @test ymean(M) == zeros(dy)
+    @test xprojection(M) == Px
+    @test yprojection(M) == Py
+    @test correlations(M) == T[0.8, 0.6, 0.4]
 
-@test xtransform(M, X) ≈ Px'X
-@test ytransform(M, Y) ≈ Py'Y
+    @test xtransform(M, X) ≈ Px'X
+    @test ytransform(M, Y) ≈ Py'Y
 
-## CCA with nonzero means
+    ## CCA with nonzero means
 
-ux = randn(dx)
-uy = randn(dy)
+    ux = randn(T, dx)
+    uy = randn(T, dy)
 
-M = CCA(ux, uy, Px, Py, [0.8, 0.6, 0.4])
+    M = CCA(ux, uy, Px, Py, T[0.8, 0.6, 0.4])
 
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test xmean(M) == ux
-@test ymean(M) == uy
-@test xprojection(M) == Px
-@test yprojection(M) == Py
-@test correlations(M) == [0.8, 0.6, 0.4]
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test xmean(M) == ux
+    @test ymean(M) == uy
+    @test xprojection(M) == Px
+    @test yprojection(M) == Py
+    @test correlations(M) == T[0.8, 0.6, 0.4]
 
-@test xtransform(M, X) ≈ Px' * (X .- ux)
-@test ytransform(M, Y) ≈ Py' * (Y .- uy)
-
+    @test xtransform(M, X) ≈ Px' * (X .- ux)
+    @test ytransform(M, Y) ≈ Py' * (Y .- uy)
+end
 
 ## prepare data
 


### PR DESCRIPTION
Closes #53. 

Lets CCA using any Dense Real Matrix
I kind of feel like this is still overly type constrained.
Why not any Number (or any type at all),
and any AbstractMatrix?



In any case `Real` is as relaxed as the type constraints get in this package.
This matches #52 


