### PR TITLE
Fixed CCA type constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,14 @@
 name = "MultivariateStats"
 uuid = "6f286f6a-111f-5878-ab1e-185364afe411"
-license = "MIT"
-repository = "https://github.com/JuliaStats/MultivariateStats.jl.git"
-desc = "A Julia package for multivariate statistics and data analysis"
 keywords = ["multivariate statistics", "dimensionality reduction"]
-
+license = "MIT"
+desc = "A Julia package for multivariate statistics and data analysis"
+repository = "https://github.com/JuliaStats/MultivariateStats.jl.git"
 version = "0.6.0"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"

--- a/src/cca.jl
+++ b/src/cca.jl
@@ -223,7 +223,7 @@ function fit(::Type{CCA}, X::AbstractMatrix{T}, Y::AbstractMatrix{T};
         throw(DimensionMismatch("X and Y should have the same number of columns."))
 
     (n >= dx && n >= dy) ||
-        warn("CCA would be numerically instable when n < dx or n < dy.")
+        @warn("CCA would be numerically instable when n < dx or n < dy.")
 
     xmv = preprocess_mean(X, xmean)
     ymv = preprocess_mean(Y, ymean)

--- a/src/common.jl
+++ b/src/common.jl
@@ -22,7 +22,7 @@ decentralize(x::AbstractMatrix, m::AbstractVector) = (isempty(m) ? x : x .+ m)
 
 fullmean(d::Int, mv::Vector{T}) where T = (isempty(mv) ? zeros(T, d) : mv)::Vector{T}
 
-preprocess_mean(X::AbstractMatrix{T}, m) where T<:AbstractFloat =
+preprocess_mean(X::AbstractMatrix{T}, m) where T<:Real =
     (m == nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)::Vector{T}
 
 # choose the first k values and columns
@@ -55,11 +55,11 @@ end
 
 # percolumn dot
 
-function coldot(X::AbstractMatrix, Y::AbstractMatrix)
+function coldot(X::AbstractMatrix{T}, Y::AbstractMatrix{T}) where T<:Real
     m = size(X, 1)
     n = size(X, 2)
     @assert size(Y) == (m, n)
-    R = zeros(n)
+    R = zeros(T, n)
     for j = 1:n
         R[j] = dot(view(X,:,j), view(Y,:,j))
     end
@@ -97,7 +97,7 @@ function add_diag!(A::AbstractMatrix, v::Real)
 end
 
 # regularize a symmetric matrix
-function regularize_symmat!(A::Matrix{T}, lambda::Real) where T<:AbstractFloat
+function regularize_symmat!(A::Matrix{T}, lambda::Real) where T<:Real
     if lambda > 0
         emax = eigmax(Symmetric(A))
         add_diag!(A, emax * lambda)

--- a/src/pca.jl
+++ b/src/pca.jl
@@ -1,7 +1,5 @@
 # Principal Component Analysis
 
-import Printf
-
 #### PCA type
 
 struct PCA{T<:AbstractFloat}
@@ -51,8 +49,7 @@ reconstruct(M::PCA{T}, y::AbstractVecOrMat{T}) where T<:AbstractFloat = decentra
 ## show & dump
 
 function show(io::IO, M::PCA)
-    pr = Printf.@sprintf("%.5f", principalratio(M))
-    print(io, "PCA(indim = $(indim(M)), outdim = $(outdim(M)), principalratio = $pr)")
+    print(io, "PCA(indim = $(indim(M)), outdim = $(outdim(M)), principalratio = $(principalratio(M)))")
 end
 
 function dump(io::IO, M::PCA)

--- a/test/cca.jl
+++ b/test/cca.jl
@@ -4,128 +4,142 @@ using Test
 import Statistics: mean, cov
 import Random
 
-Random.seed!(34568)
+@testset "CCA" begin
 
-dx = 5
-dy = 6
-p = 3
+    Random.seed!(34568)
 
-# CCA with zero means
+    dx = 5
+    dy = 6
+    p = 3
 
-X = rand(dx, 100)
-Y = rand(dy, 100)
+    # CCA with zero means
 
-Px = qr(randn(dx, dx)).Q[:, 1:p]
-Py = qr(randn(dy, dy)).Q[:, 1:p]
+    X = rand(dx, 100)
+    Y = rand(dy, 100)
 
-M = CCA(Float64[], Float64[], Px, Py, [0.8, 0.6, 0.4])
+    Px = qr(randn(dx, dx)).Q[:, 1:p]
+    Py = qr(randn(dy, dy)).Q[:, 1:p]
 
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test xmean(M) == zeros(dx)
-@test ymean(M) == zeros(dy)
-@test xprojection(M) == Px
-@test yprojection(M) == Py
-@test correlations(M) == [0.8, 0.6, 0.4]
+    M = CCA(Float64[], Float64[], Px, Py, [0.8, 0.6, 0.4])
 
-@test xtransform(M, X) ≈ Px'X
-@test ytransform(M, Y) ≈ Py'Y
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test xmean(M) == zeros(dx)
+    @test ymean(M) == zeros(dy)
+    @test xprojection(M) == Px
+    @test yprojection(M) == Py
+    @test correlations(M) == [0.8, 0.6, 0.4]
 
-## CCA with nonzero means
+    @test xtransform(M, X) ≈ Px'X
+    @test ytransform(M, Y) ≈ Py'Y
 
-ux = randn(dx)
-uy = randn(dy)
+    ## CCA with nonzero means
 
-M = CCA(ux, uy, Px, Py, [0.8, 0.6, 0.4])
+    ux = randn(dx)
+    uy = randn(dy)
 
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test xmean(M) == ux
-@test ymean(M) == uy
-@test xprojection(M) == Px
-@test yprojection(M) == Py
-@test correlations(M) == [0.8, 0.6, 0.4]
+    M = CCA(ux, uy, Px, Py, [0.8, 0.6, 0.4])
 
-@test xtransform(M, X) ≈ Px' * (X .- ux)
-@test ytransform(M, Y) ≈ Py' * (Y .- uy)
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test xmean(M) == ux
+    @test ymean(M) == uy
+    @test xprojection(M) == Px
+    @test yprojection(M) == Py
+    @test correlations(M) == [0.8, 0.6, 0.4]
 
-
-## prepare data
-
-n = 1000
-dg = 10
-G = randn(dg, n)
-
-X = randn(dx, dg) * G + 0.2 * randn(dx, n)
-Y = randn(dy, dg) * G + 0.2 * randn(dy, n)
-xm = vec(mean(X, dims=2))
-ym = vec(mean(Y, dims=2))
-Zx = X .- xm
-Zy = Y .- ym
-
-Cxx = cov(X, dims=2)
-Cyy = cov(Y, dims=2)
-Cxy = cov(X, Y, dims=2)
-Cyx = Cxy'
-
-## ccacov
-
-# X ~ Y
-M = fit(CCA, X, Y; method=:cov, outdim=p)
-Px = xprojection(M)
-Py = yprojection(M)
-rho = correlations(M)
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test outdim(M) == p
-@test xmean(M) == xm
-@test ymean(M) == ym
-@test issorted(rho; rev=true)
-
-@test Px' * Cxx * Px ≈ Matrix(I, p, p)
-@test Py' * Cyy * Py ≈ Matrix(I, p, p)
-@test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
-@test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
-@test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
-@test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
-
-# Y ~ X
-M = fit(CCA, Y, X; method=:cov, outdim=p)
-Py = xprojection(M)
-Px = yprojection(M)
-rho = correlations(M)
-@test xindim(M) == dy
-@test yindim(M) == dx
-@test outdim(M) == p
-@test xmean(M) == ym
-@test ymean(M) == xm
-@test issorted(rho; rev=true)
-
-@test Px' * Cxx * Px ≈ Matrix(I, p, p)
-@test Py' * Cyy * Py ≈ Matrix(I, p, p)
-@test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
-@test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
-@test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
-@test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
+    @test xtransform(M, X) ≈ Px' * (X .- ux)
+    @test ytransform(M, Y) ≈ Py' * (Y .- uy)
 
 
-## ccasvd
+    ## prepare data
 
-# n > d
-M = fit(CCA, X, Y; method=:svd, outdim=p)
-Px = xprojection(M)
-Py = yprojection(M)
-rho = correlations(M)
-@test xindim(M) == dx
-@test yindim(M) == dy
-@test outdim(M) == p
-@test xmean(M) == xm
-@test ymean(M) == ym
-@test issorted(rho; rev=true)
+    n = 1000
+    dg = 10
+    G = randn(dg, n)
 
-@test Px' * Cxx * Px ≈ Matrix(I, p, p)
-@test Py' * Cyy * Py ≈ Matrix(I, p, p)
-@test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
-@test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
-@test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
-@test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
+    X = randn(dx, dg) * G + 0.2 * randn(dx, n)
+    Y = randn(dy, dg) * G + 0.2 * randn(dy, n)
+    xm = vec(mean(X, dims=2))
+    ym = vec(mean(Y, dims=2))
+    Zx = X .- xm
+    Zy = Y .- ym
+
+    Cxx = cov(X, dims=2)
+    Cyy = cov(Y, dims=2)
+    Cxy = cov(X, Y, dims=2)
+    Cyx = Cxy'
+
+    ## ccacov
+
+    # X ~ Y
+    M = fit(CCA, X, Y; method=:cov, outdim=p)
+    Px = xprojection(M)
+    Py = yprojection(M)
+    rho = correlations(M)
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test outdim(M) == p
+    @test xmean(M) == xm
+    @test ymean(M) == ym
+    @test issorted(rho; rev=true)
+
+    @test Px' * Cxx * Px ≈ Matrix(I, p, p)
+    @test Py' * Cyy * Py ≈ Matrix(I, p, p)
+    @test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
+    @test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
+    @test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
+    @test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
+
+    # Y ~ X
+    M = fit(CCA, Y, X; method=:cov, outdim=p)
+    Py = xprojection(M)
+    Px = yprojection(M)
+    rho = correlations(M)
+    @test xindim(M) == dy
+    @test yindim(M) == dx
+    @test outdim(M) == p
+    @test xmean(M) == ym
+    @test ymean(M) == xm
+    @test issorted(rho; rev=true)
+
+    @test Px' * Cxx * Px ≈ Matrix(I, p, p)
+    @test Py' * Cyy * Py ≈ Matrix(I, p, p)
+    @test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
+    @test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
+    @test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
+    @test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
+
+
+    ## ccasvd
+
+    # n > d
+    M = fit(CCA, X, Y; method=:svd, outdim=p)
+    Px = xprojection(M)
+    Py = yprojection(M)
+    rho = correlations(M)
+    @test xindim(M) == dx
+    @test yindim(M) == dy
+    @test outdim(M) == p
+    @test xmean(M) == xm
+    @test ymean(M) == ym
+    @test issorted(rho; rev=true)
+
+    @test Px' * Cxx * Px ≈ Matrix(I, p, p)
+    @test Py' * Cyy * Py ≈ Matrix(I, p, p)
+    @test Cxy * (Cyy \ Cyx) * Px ≈ Cxx * Px * Diagonal(rho.^2)
+    @test Cyx * (Cxx \ Cxy) * Py ≈ Cyy * Py * Diagonal(rho.^2)
+    @test Px ≈ MultivariateStats.qnormalize!(Cxx \ (Cxy * Py), Cxx)
+    @test Py ≈ MultivariateStats.qnormalize!(Cyy \ (Cyx * Px), Cyy)
+
+    # different input type
+    XX = convert(Matrix{Float32}, X)
+    YY = convert(Matrix{Float32}, Y)
+    M = fit(CCA, view(XX, :, 1:400), view(YY, :, 1:400); method=:svd, outdim=p)
+    @test eltype(xmean(M)) == Float32
+    @test eltype(ymean(M)) == Float32
+    @test eltype(xprojection(M)) == Float32
+    @test eltype(yprojection(M)) == Float32
+    @test eltype(correlations(M)) == Float32
+
+end


### PR DESCRIPTION
Fixed CCA type constraints (closes #53)

In addition:
- Removed `Printf` dependency
- Refactored CCA tests