### PR TITLE
LREG: deprecate `trans` argument

### DIFF
--- a/docs/source/lreg.rst
+++ b/docs/source/lreg.rst
@@ -31,7 +31,7 @@ The package provides ``llsq`` to solve these problems:
 
     This function accepts two keyword arguments:
 
-    - ``trans``: whether to use the transposed form. (default is ``false``)
+    - ``dims``: whether input observations stored as rows (1) or columns (2). (default is ``2``)
     - ``bias``: whether to include the bias term ``b``. (default is ``true``)
 
     The function results the solution ``a``.
@@ -43,7 +43,7 @@ For a single response vector ``y`` (without using bias):
 
 .. code-block:: julia
 
-    using MultivariateStats
+    using Statistics, MultivariateStats
 
     # prepare data
     X = rand(1000, 3)               # feature matrix
@@ -51,13 +51,13 @@ For a single response vector ``y`` (without using bias):
     y = X * a0 + 0.1 * randn(1000)  # generate response
 
     # solve using llsq
-    a = llsq(X, y; bias=false)
+    a = llsq(X, y; dims=1, bias=false)
 
     # do prediction
     yp = X * a
 
     # measure the error
-    rmse = sqrt(mean(abs2(y - yp)))
+    rmse = sqrt(mean(abs2.(y - yp)))
     print("rmse = $rmse")
 
 For a single response vector ``y`` (using bias):
@@ -67,25 +67,25 @@ For a single response vector ``y`` (using bias):
     # prepare data
     X = rand(1000, 3)
     a0, b0 = rand(3), rand()
-    y = X * a0 + b0 + 0.1 * randn(1000)
+    y = X * a0 .+ b0 .+ 0.1 * randn(1000)
 
     # solve using llsq
-    sol = llsq(X, y)
+    sol = llsq(X, y, dims=1)
 
     # extract results
     a, b = sol[1:end-1], sol[end]
 
     # do prediction
-    yp = X * a + b'
+    yp = X * a .+ b'
 
-For a matrix ``Y`` comprised of multiple columns:
+For a matrix column-stored regressors ``X`` and  dependent variables comprised of multiple columns ``Y``:
 
 .. code-block:: julia
 
     # prepare data
-    X = rand(1000, 3)
+    X = rand(3, 1000)
     A0, b0 = rand(3, 5), rand(1, 5)
-    Y = (X * A0 .+ b0) + 0.1 * randn(1000, 5)
+    Y = (X' * A0 .+ b0) + 0.1 * randn(1000, 5)
 
     # solve using llsq
     sol = llsq(X, Y)
@@ -94,7 +94,7 @@ For a matrix ``Y`` comprised of multiple columns:
     A, b = sol[1:end-1,:], sol[end,:]
 
     # do prediction
-    Yp = X * A .+ b'
+    Yp = X'*A .+ b'
 
 
 Ridge Regression
@@ -132,7 +132,7 @@ The package provides ``ridge`` to solve these problems:
 
     This function accepts two keyword arguments:
 
-    - ``trans``: whether to use the transposed form. (default is ``false``)
+    - ``dims``: whether input observations stored as rows (1) or columns (2). (default is ``2``)
     - ``bias``: whether to include the bias term ``b``. (default is ``true``)
 
     The function results the solution ``a``.

--- a/docs/source/lreg.rst
+++ b/docs/source/lreg.rst
@@ -31,7 +31,7 @@ The package provides ``llsq`` to solve these problems:
 
     This function accepts two keyword arguments:
 
-    - ``dims``: whether input observations stored as rows (1) or columns (2). (default is ``2``)
+    - ``dims``: whether input observations are stored as rows (``1``) or columns (``2``). (default is ``1``)
     - ``bias``: whether to include the bias term ``b``. (default is ``true``)
 
     The function results the solution ``a``.
@@ -51,7 +51,7 @@ For a single response vector ``y`` (without using bias):
     y = X * a0 + 0.1 * randn(1000)  # generate response
 
     # solve using llsq
-    a = llsq(X, y; dims=1, bias=false)
+    a = llsq(X, y; bias=false)
 
     # do prediction
     yp = X * a
@@ -70,7 +70,7 @@ For a single response vector ``y`` (using bias):
     y = X * a0 .+ b0 .+ 0.1 * randn(1000)
 
     # solve using llsq
-    sol = llsq(X, y, dims=1)
+    sol = llsq(X, y)
 
     # extract results
     a, b = sol[1:end-1], sol[end]
@@ -78,7 +78,7 @@ For a single response vector ``y`` (using bias):
     # do prediction
     yp = X * a .+ b'
 
-For a matrix column-stored regressors ``X`` and  dependent variables comprised of multiple columns ``Y``:
+For a matrix of column-stored regressors ``X`` and a matrix comprised of multiple columns of dependent variables ``Y``:
 
 .. code-block:: julia
 
@@ -88,7 +88,7 @@ For a matrix column-stored regressors ``X`` and  dependent variables comprised o
     Y = (X' * A0 .+ b0) + 0.1 * randn(1000, 5)
 
     # solve using llsq
-    sol = llsq(X, Y)
+    sol = llsq(X, Y, dims=2)
 
     # extract results
     A, b = sol[1:end-1,:], sol[end,:]
@@ -132,7 +132,7 @@ The package provides ``ridge`` to solve these problems:
 
     This function accepts two keyword arguments:
 
-    - ``dims``: whether input observations stored as rows (1) or columns (2). (default is ``2``)
+    - ``dims``: whether input observations are stored as rows (``1``) or columns (``2``). (default is ``1``)
     - ``bias``: whether to include the bias term ``b``. (default is ``true``)
 
     The function results the solution ``a``.

--- a/src/lreg.jl
+++ b/src/lreg.jl
@@ -22,9 +22,9 @@ _haug(X::AbstractMatrix{T}) where T = hcat(X, ones(T, size(X,1), 1))::Matrix{T}
 function llsq(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T};
               trans::Bool=false, bias::Bool=true,
               dims::Union{Integer,Nothing}=nothing) where {T<:Real}
-    if dims === nothing
+    if dims === nothing && trans
         Base.depwarn("`trans` argument is deprecated, use llsq(X, Y, dims=d) instead.", :trans)
-        dims = 2
+        dims = 1
     end
     if dims == 2
         mX, nX = size(X)
@@ -43,9 +43,9 @@ end
 function ridge(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T}, r::Union{Real, AbstractVecOrMat};
                trans::Bool=false, bias::Bool=true,
                dims::Union{Integer,Nothing}=nothing) where {T<:Real}
-    if dims === nothing
+    if dims === nothing && trans
         Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
-        dims = 2
+        dims = 1
     end
     d = lreg_chkdims(X, Y, dims == 2)
     if isa(r, Real)

--- a/src/lreg.jl
+++ b/src/lreg.jl
@@ -40,39 +40,22 @@ end
 
 ## ridge regression
 
-function ridge(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T}, r::Real;
+function ridge(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T}, r::Union{Real, AbstractVecOrMat};
                trans::Bool=false, bias::Bool=true,
                dims::Union{Integer,Nothing}=nothing) where {T<:Real}
     if dims === nothing
         Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
         dims = 2
     end
-    lreg_chkdims(X, Y, dims == 2)
-    r >= zero(r) || error("r must be non-negative.")
-    _ridge(X, Y, convert(T, r), dims == 2, bias)
-end
-
-function ridge(X::AbstractMatrix, Y::AbstractVecOrMat, r::AbstractVector;
-               trans::Bool=false, bias::Bool=true,
-               dims::Union{Integer,Nothing}=nothing)
-    if dims === nothing
-        Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
-        dims = 2
-    end
     d = lreg_chkdims(X, Y, dims == 2)
-    length(r) == d || throw(DimensionMismatch("Incorrect length of r."))
-    _ridge(X, Y, r, dims == 2, bias)
-end
-
-function ridge(X::AbstractMatrix, Y::AbstractVecOrMat, r::AbstractMatrix;
-               trans::Bool=false, bias::Bool=true,
-               dims::Union{Integer,Nothing}=nothing)
-    if dims === nothing
-        Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
-        dims = 2
+    if isa(r, Real)
+        r >= zero(r) || error("r must be non-negative.")
+        r = convert(T, r)
+    elseif isa(r, AbstractVector)
+        length(r) == d || throw(DimensionMismatch("Incorrect length of r."))
+    elseif isa(r, AbstractMatrix)
+        size(r) == (d, d) || throw(DimensionMismatch("Incorrect size of r."))
     end
-    d = lreg_chkdims(X, Y, dims == 2)
-    size(r) == (d, d) || throw(DimensionMismatch("Incorrect size of r."))
     _ridge(X, Y, r, dims == 2, bias)
 end
 

--- a/src/lreg.jl
+++ b/src/lreg.jl
@@ -20,8 +20,13 @@ _haug(X::AbstractMatrix{T}) where T = hcat(X, ones(T, size(X,1), 1))::Matrix{T}
 ## linear least square
 
 function llsq(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T};
-              trans::Bool=false, bias::Bool=true) where {T<:Real}
-    if trans
+              trans::Bool=false, bias::Bool=true,
+              dims::Union{Integer,Nothing}=nothing) where {T<:Real}
+    if dims === nothing
+        Base.depwarn("`trans` argument is deprecated, use llsq(X, Y, dims=d) instead.", :trans)
+        dims = 2
+    end
+    if dims == 2
         mX, nX = size(X)
         size(Y, 1) == nX || throw(DimensionMismatch("Dimensions of X and Y mismatch."))
         mX <= nX || error("mX <= nX is required when trans is false.")
@@ -30,30 +35,45 @@ function llsq(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T};
         size(Y, 1) == mX || throw(DimensionMismatch("Dimensions of X and Y mismatch."))
         mX >= nX || error("mX >= nX is required when trans is false.")
     end
-    _ridge(X, Y, zero(T), trans, bias)
+    _ridge(X, Y, zero(T), dims == 2, bias)
 end
 
 ## ridge regression
 
 function ridge(X::AbstractMatrix{T}, Y::AbstractVecOrMat{T}, r::Real;
-               trans::Bool=false, bias::Bool=true) where {T<:Real}
-    lreg_chkdims(X, Y, trans)
+               trans::Bool=false, bias::Bool=true,
+               dims::Union{Integer,Nothing}=nothing) where {T<:Real}
+    if dims === nothing
+        Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
+        dims = 2
+    end
+    lreg_chkdims(X, Y, dims == 2)
     r >= zero(r) || error("r must be non-negative.")
-    _ridge(X, Y, convert(T, r), trans, bias)
+    _ridge(X, Y, convert(T, r), dims == 2, bias)
 end
 
 function ridge(X::AbstractMatrix, Y::AbstractVecOrMat, r::AbstractVector;
-               trans::Bool=false, bias::Bool=true)
-    d = lreg_chkdims(X, Y, trans)
+               trans::Bool=false, bias::Bool=true,
+               dims::Union{Integer,Nothing}=nothing)
+    if dims === nothing
+        Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
+        dims = 2
+    end
+    d = lreg_chkdims(X, Y, dims == 2)
     length(r) == d || throw(DimensionMismatch("Incorrect length of r."))
-    _ridge(X, Y, r, trans, bias)
+    _ridge(X, Y, r, dims == 2, bias)
 end
 
 function ridge(X::AbstractMatrix, Y::AbstractVecOrMat, r::AbstractMatrix;
-               trans::Bool=false, bias::Bool=true)
-    d = lreg_chkdims(X, Y, trans)
+               trans::Bool=false, bias::Bool=true,
+               dims::Union{Integer,Nothing}=nothing)
+    if dims === nothing
+        Base.depwarn("`trans` argument is deprecated, use ridge(X, Y, r, dims=d) instead.", :trans)
+        dims = 2
+    end
+    d = lreg_chkdims(X, Y, dims == 2)
     size(r) == (d, d) || throw(DimensionMismatch("Incorrect size of r."))
-    _ridge(X, Y, r, trans, bias)
+    _ridge(X, Y, r, dims == 2, bias)
 end
 
 ## implementation

--- a/test/lreg.jl
+++ b/test/lreg.jl
@@ -61,10 +61,10 @@ import Random
     @test aa ≈ Aa[:,1]
 
     # test default dims=2 argument
-    aa = llsq(Xt, y1)
+    aa = llsq(X, y1)
     @test aa ≈ Aa[:,1]
-    @test_throws DimensionMismatch llsq(X, y0)
-    @test_throws DimensionMismatch llsq(Xt, y1; dims=1)
+    @test_throws DimensionMismatch llsq(X, y1; dims=2)
+    @test_throws DimensionMismatch llsq(Xt, y1)
 
 
     ## ridge (with Real r)
@@ -104,10 +104,10 @@ import Random
     @test aa ≈ Aa[:,1]
 
     # test default dims=2 argument
-    aa = ridge(Xt, y1, r)
+    aa = ridge(X, y1, r)
     @test aa ≈ Aa[:,1]
-    @test_throws DimensionMismatch ridge(X, y0, r)
-    @test_throws DimensionMismatch ridge(Xt, y1, r; dims=1)
+    @test_throws DimensionMismatch ridge(X, y1, r; dims=2)
+    @test_throws DimensionMismatch ridge(Xt, y1, r)
 
 
     ## ridge (with diagonal r)

--- a/test/lreg.jl
+++ b/test/lreg.jl
@@ -60,6 +60,12 @@ import Random
     aa = llsq(Xt, y1; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
 
+    # test default dims=2 argument
+    aa = llsq(Xt, y1)
+    @test aa ≈ Aa[:,1]
+    @test_throws DimensionMismatch llsq(X, y0)
+    @test_throws DimensionMismatch llsq(Xt, y1; dims=1)
+
 
     ## ridge (with Real r)
 
@@ -96,6 +102,12 @@ import Random
 
     aa = ridge(Xt, y1, r; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
+
+    # test default dims=2 argument
+    aa = ridge(Xt, y1, r)
+    @test aa ≈ Aa[:,1]
+    @test_throws DimensionMismatch ridge(X, y0, r)
+    @test_throws DimensionMismatch ridge(Xt, y1, r; dims=1)
 
 
     ## ridge (with diagonal r)

--- a/test/lreg.jl
+++ b/test/lreg.jl
@@ -28,36 +28,36 @@ import Random
 
     ## llsq
 
-    A = llsq(X, Y0; trans=false, bias=false)
+    A = llsq(X, Y0; dims=1, bias=false)
     A_r = copy(A)
     @test size(A) == (n, n2)
     @test X'Y0 ≈ X'X * A
 
-    a = llsq(X, y0; trans=false, bias=false)
+    a = llsq(X, y0; dims=1, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    A = llsq(Xt, Y0; trans=true, bias=false)
+    A = llsq(Xt, Y0; dims=2, bias=false)
     @test size(A) == (n, n2)
     @test A ≈ A_r
 
-    a = llsq(Xt, y0; trans=true, bias=false)
+    a = llsq(Xt, y0; dims=2, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    Aa = llsq(X, Y1; trans=false, bias=true)
+    Aa = llsq(X, Y1; dims=1, bias=true)
     Aa_r = copy(Aa)
     @test size(Aa) == (n+1, n2)
     A, b = Aa[1:end-1,:], Aa[end:end,:]
     @test X' * (Y1 .- b) ≈ X'X * A
 
-    aa = llsq(X, y1; trans=false, bias=true)
+    aa = llsq(X, y1; dims=1, bias=true)
     @test aa ≈ Aa[:,1]
 
-    Aa = llsq(Xt, Y1; trans=true, bias=true)
+    Aa = llsq(Xt, Y1; dims=2, bias=true)
     @test Aa ≈ Aa_r
 
-    aa = llsq(Xt, y1; trans=true, bias=true)
+    aa = llsq(Xt, y1; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
 
 
@@ -65,36 +65,36 @@ import Random
 
     r = 0.1
 
-    A = ridge(X, Y0, r; trans=false, bias=false)
+    A = ridge(X, Y0, r; dims=1, bias=false)
     A_r = copy(A)
     @test size(A) == (n, n2)
     @test X'Y0 ≈ (X'X + r * I) * A
 
-    a = ridge(X, y0, r; trans=false, bias=false)
+    a = ridge(X, y0, r; dims=1, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    A = ridge(Xt, Y0, r; trans=true, bias=false)
+    A = ridge(Xt, Y0, r; dims=2, bias=false)
     @test size(A) == (n, n2)
     @test A ≈ A_r
 
-    a = ridge(Xt, y0, r; trans=true, bias=false)
+    a = ridge(Xt, y0, r; dims=2, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    Aa = ridge(X, Y1, r; trans=false, bias=true)
+    Aa = ridge(X, Y1, r; dims=1, bias=true)
     Aa_r = copy(Aa)
     @test size(Aa) == (n+1, n2)
     A, b = Aa[1:end-1,:], Aa[end:end,:]
     @test X' * (Y1 .- b) ≈ (X'X + r * I) * A
 
-    aa = ridge(X, y1, r; trans=false, bias=true)
+    aa = ridge(X, y1, r; dims=1, bias=true)
     @test aa ≈ Aa[:,1]
 
-    Aa = ridge(Xt, Y1, r; trans=true, bias=true)
+    Aa = ridge(Xt, Y1, r; dims=2, bias=true)
     @test Aa ≈ Aa_r
 
-    aa = ridge(Xt, y1, r; trans=true, bias=true)
+    aa = ridge(Xt, y1, r; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
 
 
@@ -102,36 +102,36 @@ import Random
 
     r = 0.05 .+ 0.1 .* rand(n)
 
-    A = ridge(X, Y0, r; trans=false, bias=false)
+    A = ridge(X, Y0, r; dims=1, bias=false)
     A_r = copy(A)
     @test size(A) == (n, n2)
     @test X'Y0 ≈ (X'X + diagm(0=>r)) * A
 
-    a = ridge(X, y0, r; trans=false, bias=false)
+    a = ridge(X, y0, r; dims=1, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    A = ridge(Xt, Y0, r; trans=true, bias=false)
+    A = ridge(Xt, Y0, r; dims=2, bias=false)
     @test size(A) == (n, n2)
     @test A ≈ A_r
 
-    a = ridge(Xt, y0, r; trans=true, bias=false)
+    a = ridge(Xt, y0, r; dims=2, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    Aa = ridge(X, Y1, r; trans=false, bias=true)
+    Aa = ridge(X, Y1, r; dims=1, bias=true)
     Aa_r = copy(Aa)
     @test size(Aa) == (n+1, n2)
     A, b = Aa[1:end-1,:], Aa[end:end,:]
     @test X' * (Y1 .- b) ≈ (X'X + diagm(0=>r)) * A
 
-    aa = ridge(X, y1, r; trans=false, bias=true)
+    aa = ridge(X, y1, r; dims=1, bias=true)
     @test aa ≈ Aa[:,1]
 
-    Aa = ridge(Xt, Y1, r; trans=true, bias=true)
+    Aa = ridge(Xt, Y1, r; dims=2, bias=true)
     @test Aa ≈ Aa_r
 
-    aa = ridge(Xt, y1, r; trans=true, bias=true)
+    aa = ridge(Xt, y1, r; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
 
 
@@ -140,36 +140,36 @@ import Random
     Q = qr(randn(n, n)).Q
     r = Q' * diagm(0=>r) * Q
 
-    A = ridge(X, Y0, r; trans=false, bias=false)
+    A = ridge(X, Y0, r; dims=1, bias=false)
     A_r = copy(A)
     @test size(A) == (n, n2)
     @test X'Y0 ≈ (X'X + r) * A
 
-    a = ridge(X, y0, r; trans=false, bias=false)
+    a = ridge(X, y0, r; dims=1, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    A = ridge(Xt, Y0, r; trans=true, bias=false)
+    A = ridge(Xt, Y0, r; dims=2, bias=false)
     @test size(A) == (n, n2)
     @test A ≈ A_r
 
-    a = ridge(Xt, y0, r; trans=true, bias=false)
+    a = ridge(Xt, y0, r; dims=2, bias=false)
     @test size(a) == (n,)
     @test a ≈ A[:,1]
 
-    Aa = ridge(X, Y1, r; trans=false, bias=true)
+    Aa = ridge(X, Y1, r; dims=1, bias=true)
     Aa_r = copy(Aa)
     @test size(Aa) == (n+1, n2)
     A, b = Aa[1:end-1,:], Aa[end:end,:]
     @test X' * (Y1 .- b) ≈ (X'X + r) * A
 
-    aa = ridge(X, y1, r; trans=false, bias=true)
+    aa = ridge(X, y1, r; dims=1, bias=true)
     @test aa ≈ Aa[:,1]
 
-    Aa = ridge(Xt, Y1, r; trans=true, bias=true)
+    Aa = ridge(Xt, Y1, r; dims=2, bias=true)
     @test Aa ≈ Aa_r
 
-    aa = ridge(Xt, y1, r; trans=true, bias=true)
+    aa = ridge(Xt, y1, r; dims=2, bias=true)
     @test aa ≈ Aa[:,1]
 
 end


### PR DESCRIPTION
Deprecate `trans` in favor of `dims`  argument