### PR TITLE
stop using DataArray for conversion

### DIFF
--- a/docs/source/pca.rst
+++ b/docs/source/pca.rst
@@ -153,12 +153,12 @@ One can use the ``fit`` method to perform PCA over a given dataset.
     iris = dataset("datasets", "iris")
 
     # split half to training set
-    Xtr = convert(Array,DataArray(iris[1:2:end,1:4]))'
-    Xtr_labels = convert(Array,DataArray(iris[1:2:end,5]))
+    Xtr = convert(Matrix, iris[1:2:end,1:4])'
+    Xtr_labels = convert(Vector, iris[1:2:end,5])
 
     # split other half to testing set
-    Xte = convert(Array,DataArray(iris[2:2:end,1:4]))'
-    Xte_labels = convert(Array,DataArray(iris[2:2:end,5]))
+    Xte = convert(Matrix, iris[2:2:end,1:4])'
+    Xte_labels = convert(Vector, iris[2:2:end,5])
 
     # suppose Xtr and Xte are training and testing data matrix,
     # with each observation in a column


### PR DESCRIPTION
I ran into a problem when trying the PCA example.  Looks like DataArrays.jl is deprecated and the current version of DataFrame allows easy conversion to Matrix or Vector.

My config:
```
(v1.1) pkg> st DataFrames
    Status `~/.julia/environments/v1.1/Project.toml`
  [a93c6f00] DataFrames v0.18.2
  [2913bbd2] StatsBase v0.30.0
  [bd369af6] Tables v0.2.4

(v1.1) pkg> st MultivariateStats
    Status `~/.julia/environments/v1.1/Project.toml`
  [6f286f6a] MultivariateStats v0.6.0
  [2913bbd2] StatsBase v0.30.0
```