### PR TITLE
Add PCA loadings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,15 +9,16 @@ version = "0.7.0"
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[compat]
+StatsBase = ">=0.29"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[compat]
-StatsBase = ">=0.29"

--- a/src/pca.jl
+++ b/src/pca.jl
@@ -41,6 +41,8 @@ tvar(M::PCA) = M.tvar
 
 principalratio(M::PCA) = M.tprinvar / M.tvar
 
+loadings(M::PCA) = sqrt.(principalvars(M))' .* projection(M)
+
 ## use
 
 transform(M::PCA{T}, x::AbstractVecOrMat{T}) where {T<:Real} = transpose(M.proj) * centralize(x, M.mean)

--- a/test/pca.jl
+++ b/test/pca.jl
@@ -16,6 +16,11 @@ import SparseArrays
 
     P = qr(randn(5, 5)).Q[:, 1:3]
     pvars = [5., 4., 3.]
+    l = [-0.809509  -1.14456    0.944145
+    -0.738713  -1.23353   -0.607874;
+    -1.64431    0.875826  -0.479549;
+    -0.816033   0.613632   1.06775 ;
+     0.655236   0.157369   0.607475]
     M = PCA(Float64[], P, pvars, 15.0)
 
     @test indim(M) == 5
@@ -28,6 +33,7 @@ import SparseArrays
     @test tprincipalvar(M) == 12.0
     @test tresidualvar(M) == 3.0
     @test principalratio(M) == 0.8
+    @test isapprox(loadings(M),l, atol = 0.001)
 
     @test transform(M, X[:,1]) ≈ P'X[:,1]
     @test transform(M, X) ≈ P'X


### PR DESCRIPTION
This PR adds 
1. a `loadings` function for `PCA` objects - in support of https://github.com/JuliaStats/MultivariateStats.jl/issues/109.
2. adds `Random` as a dep to the `Project.toml`. I was unable to test locally until I added this and the most recent Travis run shows up as failed. If this is mistaken, I can remove it.
I also checked output against the `principal` function in the `psych` library [similar to here.](https://discourse.julialang.org/t/pca-output/22687/4)

Suggestions welcome.
