### PR TITLE
loosen type bounds in `MulticlassLDA` and `MulticlassldaStats`

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -23,7 +23,7 @@ decentralize(x::AbstractMatrix, m::AbstractVector) = (isempty(m) ? x : x .+ m)
 fullmean(d::Int, mv::Vector{T}) where T = (isempty(mv) ? zeros(T, d) : mv)::Vector{T}
 
 preprocess_mean(X::AbstractMatrix{T}, m) where T<:Real =
-    (m === nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)
+    (m == nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)::Vector{T}
 
 # choose the first k values and columns
 #
@@ -97,7 +97,7 @@ function add_diag!(A::AbstractMatrix, v::Real)
 end
 
 # regularize a symmetric matrix
-function regularize_symmat!(A::Matrix{T}, lambda::Real) where T<:Real
+function regularize_symmat!(A::AbstractMatrix{T}, lambda::Real) where T<:Real
     if lambda > 0
         emax = eigmax(Symmetric(A))
         add_diag!(A, emax * lambda)

--- a/src/common.jl
+++ b/src/common.jl
@@ -20,7 +20,7 @@ decentralize(x::AbstractMatrix, m::AbstractVector) = (isempty(m) ? x : x .+ m)
 
 # get a full mean vector
 
-fullmean(d::Int, mv::Vector{T}) where T = (isempty(mv) ? zeros(T, d) : mv)::Vector{T}
+fullmean(d::Int, mv::Vector{T}) where T = (isempty(mv) ? zeros(T, d) : mv)
 
 preprocess_mean(X::AbstractMatrix{T}, m) where T<:Real =
     (m == nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)::Vector{T}

--- a/src/common.jl
+++ b/src/common.jl
@@ -23,7 +23,7 @@ decentralize(x::AbstractMatrix, m::AbstractVector) = (isempty(m) ? x : x .+ m)
 fullmean(d::Int, mv::Vector{T}) where T = (isempty(mv) ? zeros(T, d) : mv)
 
 preprocess_mean(X::AbstractMatrix{T}, m) where T<:Real =
-    (m == nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)::Vector{T}
+    (m === nothing ? vec(mean(X, dims=2)) : m == 0 ? T[] :  m)
 
 # choose the first k values and columns
 #

--- a/src/lda.jl
+++ b/src/lda.jl
@@ -165,7 +165,7 @@ mclda_solve(Sb::AbstractMatrix{T}, Sw::AbstractMatrix{T}, method::Symbol, p::Int
     mclda_solve!(copy(Sb), copy(Sw), method, p, regcoef)
 
 function mclda_solve!(Sb::AbstractMatrix{T},
-                      Sw::AbstractMatrix{T}
+                      Sw::AbstractMatrix{T},
                       method::Symbol, p::Int, regcoef::T) where T<:Real
 
     p <= size(Sb, 1) || throw(ArgumentError("p cannot exceed sample dimension."))


### PR DESCRIPTION
This PR loosen type restriction in `MulticlassLDA` and `MulticlassldaStats`. This was done to allow using `CovarianceEstimator`'s from **CovarianceEstimation.jl** and other more general Estimators in estimating scattter matrices used in `MuticlassLDA` model. (which is currently not possible on #master).
I believe this would help other packages integrate better with MultivariateStats
@wildart