### PR TITLE
Add orthomax factor rotations

### DIFF
--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -2,7 +2,7 @@ module MultivariateStats
     using LinearAlgebra
     using StatsBase: SimpleCovariance, CovarianceEstimator
     import Statistics: mean, var, cov, covm
-    import Base: length, size, show, dump
+    import Base: length, size, show, dump, eltype
     import StatsBase: fit, predict, ConvergenceException
     import SparseArrays
     import LinearAlgebra: eigvals
@@ -10,109 +10,116 @@ module MultivariateStats
     export
 
     ## common
-    evaluate,           # evaluate discriminant function values (imported from Base)
-    predict,            # use a model to predict responses (imported from StatsBase)
-    fit,                # fit a model to data (imported from StatsBase)
-    centralize,         # subtract a mean vector from each column
-    decentralize,       # add a mean vector to each column
-    indim,              # the input dimension of a model
-    outdim,             # the output dimension of a model
-    projection,         # the projection matrix
-    reconstruct,        # reconstruct the input (approximately) given the output
-    transform,          # apply a model to transform a vector or a matrix
+    evaluate,                  # evaluate discriminant function values (imported from Base)
+    predict,                   # use a model to predict responses (imported from StatsBase)
+    fit,                       # fit a model to data (imported from StatsBase)
+    centralize,                # subtract a mean vector from each column
+    decentralize,              # add a mean vector to each column
+    indim,                     # the input dimension of a model
+    outdim,                    # the output dimension of a model
+    projection,                # the projection matrix
+    reconstruct,               # reconstruct the input (approximately) given the output
+    transform,                 # apply a model to transform a vector or a matrix
 
-    # lreg
-    llsq,               # Linear Least Square regression
-    ridge,              # Ridge regression
+    ## lreg
+    llsq,                      # Linear Least Square regression
+    ridge,                     # Ridge regression
 
-    # whiten
-    Whitening,          # Type: Whitening transformation
+    ## whiten
+    Whitening,                 # Type: Whitening transformation
 
-    invsqrtm,           # Compute inverse of matrix square root, i.e. inv(sqrtm(A))
-    invsqrtm!,          # Compute inverse of matrix square root inplace
-    cov_whitening,      # Compute a whitening transform based on covariance
-    cov_whitening!,     # Compute a whitening transform based on covariance (input will be overwritten)
-    invsqrtm,           # Compute C^{-1/2}, i.e. inv(sqrtm(C))
+    invsqrtm,                  # Compute inverse of matrix square root, i.e. inv(sqrtm(A))
+    invsqrtm!,                 # Compute inverse of matrix square root inplace
+    cov_whitening,             # Compute a whitening transform based on covariance
+    cov_whitening!,            # Compute a whitening transform based on covariance (input will be overwritten)
+    invsqrtm,                  # Compute C^{-1/2}, i.e. inv(sqrtm(C))
 
     ## pca
-    PCA,                # Type: Principal Component Analysis model
+    PCA,                       # Type: Principal Component Analysis model
 
-    pcacov,             # PCA based on covariance
-    pcasvd,             # PCA based on singular value decomposition of input data
-    principalratio,     # the ratio of variances preserved in the principal subspace
-    principalvar,       # the variance along a specific principal direction
-    principalvars,      # the variances along all principal directions
+    pcacov,                    # PCA based on covariance
+    pcasvd,                    # PCA based on singular value decomposition of input data
+    principalratio,            # the ratio of variances preserved in the principal subspace
+    principalvar,              # the variance along a specific principal direction
+    principalvars,             # the variances along all principal directions
 
-    tprincipalvar,      # total principal variance, i.e. sum(principalvars(M))
-    tresidualvar,       # total residual variance
-    tvar,               # total variance
+    tprincipalvar,             # total principal variance, i.e. sum(principalvars(M))
+    tresidualvar,              # total residual variance
+    tvar,                      # total variance
 
     ## ppca
-    PPCA,               # Type: the Probabilistic PCA model
+    PPCA,                      # Type: the Probabilistic PCA model
 
-    ppcaml,             # Maximum likelihood probabilistic PCA
-    ppcaem,             # EM algorithm for probabilistic PCA
-    bayespca,           # Bayesian PCA
-    loadings,           # factor loadings matrix
+    ppcaml,                    # Maximum likelihood probabilistic PCA
+    ppcaem,                    # EM algorithm for probabilistic PCA
+    bayespca,                  # Bayesian PCA
+    loadings,                  # factor loadings matrix
 
     ## kpca
-    KernelPCA,          # Type: the Kernel PCA model
+    KernelPCA,                 # Type: the Kernel PCA model
 
     ## cca
-    CCA,                # Type: Correlation Component Analysis model
+    CCA,                       # Type: Correlation Component Analysis model
 
-    ccacov,             # CCA based on covariances
-    ccasvd,             # CCA based on singular value decomposition of input data
+    ccacov,                    # CCA based on covariances
+    ccasvd,                    # CCA based on singular value decomposition of input data
 
-    xindim,             # input dimension of X
-    yindim,             # input dimension of Y
-    xmean,              # sample mean of X
-    ymean,              # sample mean of Y
-    xprojection,        # projection matrix for X
-    yprojection,        # projection matrix for Y
-    xtransform,         # transform for X
-    ytransform,         # transform for Y
-    correlations,       # correlations of all projected directions
+    xindim,                    # input dimension of X
+    yindim,                    # input dimension of Y
+    xmean,                     # sample mean of X
+    ymean,                     # sample mean of Y
+    xprojection,               # projection matrix for X
+    yprojection,               # projection matrix for Y
+    xtransform,                # transform for X
+    ytransform,                # transform for Y
+    correlations,              # correlations of all projected directions
 
     ## cmds
     MDS,
-    classical_mds,      # perform classical MDS over a given distance matrix
-    eigvals,            # eignenvalues of the transformation
-    stress,             # stress evaluation
+    classical_mds,             # perform classical MDS over a given distance matrix
+    eigvals,                   # eignenvalues of the transformation
+    stress,                    # stress evaluation
 
-    gram2dmat, gram2dmat!,  # Gram matrix => Distance matrix
-    dmat2gram, dmat2gram!,  # Distance matrix => Gram matrix
+    gram2dmat, gram2dmat!,     # Gram matrix => Distance matrix
+    dmat2gram, dmat2gram!,     # Distance matrix => Gram matrix
 
     ## lda
-    Discriminant,           # Abstract Type: for all discriminant functionals
-    LinearDiscriminant,     # Type: Linear Discriminant functional
-    MulticlassLDAStats,     # Type: Statistics required for training multi-class LDA
-    MulticlassLDA,          # Type: Multi-class LDA model
-    SubspaceLDA,            # Type: LDA model for high-dimensional spaces
+    Discriminant,              # Abstract Type: for all discriminant functionals
+    LinearDiscriminant,        # Type: Linear Discriminant functional
+    MulticlassLDAStats,        # Type: Statistics required for training multi-class LDA
+    MulticlassLDA,             # Type: Multi-class LDA model
+    SubspaceLDA,               # Type: LDA model for high-dimensional spaces
 
-    ldacov,                 # Linear discriminant analysis based on covariances
+    ldacov,                    # Linear discriminant analysis based on covariances
 
-    classweights,           # class-specific weights
-    classmeans,             # class-specific means
-    withclass_scatter,      # with-class scatter matrix
-    betweenclass_scatter,   # between-class scatter matrix
-    multiclass_lda_stats,   # compute statistics for multiclass LDA training
-    multiclass_lda,         # train multi-class LDA based on statistics
-    mclda_solve,            # solve multi-class LDA projection given scatter matrices
-    mclda_solve!,           # solve multi-class LDA projection (inputs are overriden)
+    classweights,              # class-specific weights
+    classmeans,                # class-specific means
+    withclass_scatter,         # with-class scatter matrix
+    betweenclass_scatter,      # between-class scatter matrix
+    multiclass_lda_stats,      # compute statistics for multiclass LDA training
+    multiclass_lda,            # train multi-class LDA based on statistics
+    mclda_solve,               # solve multi-class LDA projection given scatter matrices
+    mclda_solve!,              # solve multi-class LDA projection (inputs are overriden)
 
     ## ica
-    ICA,                    # Type: the Fast ICA model
+    ICA,                       # Type: the Fast ICA model
 
-    icagfun,                # a function to get a ICA approx neg-entropy functor
-    fastica!,               # core algorithm function for the Fast ICA
+    icagfun,                   # a function to get a ICA approx neg-entropy functor
+    fastica!,                  # core algorithm function for the Fast ICA
 
     ## fa
-    FactorAnalysis,         # Type: the Factor Analysis model
+    FactorAnalysis,            # Type: the Factor Analysis model
 
-    faem,                   # Maximum likelihood probabilistic PCA
-    facm                    # EM algorithm for probabilistic PCA
+    faem,                      # Maximum likelihood probabilistic PCA
+    facm,                      # EM algorithm for probabilistic PCA
 
+    ## facrot
+    FactorRotationAlgorithm,   # Type: Factor rotation algorithm
+    Orthomax,                  # Type: Orthomax factor rotation algorithm
+
+    FactorRotation,            # Type: Return type for factor rotations
+    
+    rotatefactors              # Alternative interface to factor rotations
 
     ## source files
     include("common.jl")
@@ -126,5 +133,6 @@ module MultivariateStats
     include("lda.jl")
     include("ica.jl")
     include("fa.jl")
+    include("facrot.jl")
 
 end # module

--- a/src/facrot.jl
+++ b/src/facrot.jl
@@ -1,0 +1,179 @@
+"""
+    FactorRotationAlgorithm
+
+An abstract type for factor rotation algorithms.
+"""
+abstract type FactorRotationAlgorithm end
+
+"""
+    Orthomax <: FactorRotationAlgorithm
+
+A type representing the orthomax factor rotation algorithm.
+
+The positive parameter `γ::Real` determines which type of rotation is performed.
+For a `n x p` matrix, the default `γ = 1.0` leads to varimax rotation, `γ = 0.0` 
+is quartimax rotation, `γ = p / 2` is equamax rotation, and 
+`γ = n (p - 1) / (n + p - 2)` is parsimax rotation.
+
+The parameter `maxiter::Integer` controls the maximum number of iterations to
+perform (default `1000`) and `ϵ::Real` is a small positive constant determining
+convergence (default `1e-12`).
+"""
+struct Orthomax <: FactorRotationAlgorithm
+  γ::Real
+  miniter::Integer
+  maxiter::Integer
+  ϵ::Real
+
+  Orthomax(;γ = 1.0, miniter = 20, maxiter = 1000, ϵ = 1e-12) = begin
+    maxiter > zero(eltype(maxiter)) || throw(ArgumentError("Orthomax: maxiter needs to be positive"))
+    miniter > zero(eltype(miniter)) || throw(ArgumentError("Orthomax: miniter needs to be positive"))
+    γ > zero(eltype(γ)) || throw(ArgumentError("Orthomax: γ needs to be positive"))
+    ϵ > zero(eltype(ϵ)) || throw(ArgumentError("Orthomax: ϵ needs to be positive"))
+    
+    new(γ, miniter, maxiter, ϵ)
+  end
+end
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, alg::Orthomax)
+  summary(io, alg); println(io)
+  println(io, "γ = $(alg.γ)")
+  println(io, "miniter = $(alg.miniter)")
+  println(io, "maxiter = $(alg.maxiter)")
+  println(io, "ϵ = $(alg.ϵ)")
+end
+
+"""
+    FactorRotation{T <: Real}
+
+The return type for factor rotations.
+
+`F` contains the rotated factors and `R` is the rotation matrix that
+was applied to the original factors.
+"""
+struct FactorRotation{T <: Real, Ta <: FactorRotationAlgorithm}
+  F::Matrix{T}
+  R::Matrix{T}
+
+  alg::Ta
+
+  FactorRotation{T, Ta}(F, R, alg) where {T <: Real, Ta <: FactorRotationAlgorithm} = new{T, Ta}(F, R, alg)
+end
+
+eltype(::Type{FactorRotation{T, Ta}}) where {T,Ta} = T
+
+FactorRotation(F::Matrix{T}, R::Matrix{T}, alg::Ta) where {T <: Real, Ta <: FactorRotationAlgorithm} = FactorRotation{T, Ta}(F, R, alg)
+FactorRotation(F::Matrix{T}, alg::Ta) where {T <: Real, Ta <: FactorRotationAlgorithm} = FactorRotation(F, Matrix{eltype(F)}(I, size(F, 2), size(F, 2)), alg)
+
+function FactorRotation(F::Matrix, R::Matrix, alg::Ta) where {Ta <: FactorRotationAlgorithm}
+  return FactorRotation(promote(F, R)..., alg)
+end
+
+function show(io::IO, mime::MIME{Symbol("text/plain")}, FR::FactorRotation{<:Any,<:Any})
+  summary(io, FR); println(io)
+end
+
+
+## Comparison to other implementations
+# The implementation of varimax in R row-normlises the input matrix before
+# application of the algorithm and rescales the rows afterwards.
+## Reference 
+# Mikkel B. Stegmann, Karl Sjöstrand, Rasmus Larsen, "Sparse modeling of 
+# landmark and texture variability using the orthomax criterion," 
+# Proc. SPIE 6144, Medical Imaging 2006: Image Processing, 61441G
+# (10 March 2006); doi: 10.1117/12.651293
+function orthomax(F::AbstractMatrix, γ, miniter, maxiter, ϵ)
+  n, p = size(F)
+  if n < 2
+    return (F, Matrix{eltype(F)}(I, p, p))
+  end
+
+  # Warm up step
+  # Do one step. If that first step did not lead away from the identity
+  # matrix enough use a random orthogonal matrix as a starting point.
+  M = svd(F' * (F .^ 3 - γ / n * F * Diagonal(vec(sum(F .^ 2, dims=1)))))
+  R = M.U * M.Vt
+  if norm(R - Matrix{eltype(R)}(I, p, p)) < ϵ
+    R, _ = qr(randn(p, p)).Q
+  end
+
+  # Main iterations
+  d = 0
+  converged = false
+  for i in 1:maxiter
+    dold  = d
+    B = F * R
+    M = svd(F' * (B .^ 3 - γ / n * B * Diagonal(vec(sum(B .^ 2, dims=1)))))
+    R = M.U * M.Vt
+    d = sum(M.S)
+    if abs(d - dold) / d < ϵ && i >= miniter
+      converged = true
+      break
+    end
+  end
+
+  if !converged
+    @warn "orthomax did not converge in $(maxiter) iterations"
+  end
+
+  (F * R, R)
+end
+
+"""
+    fit(::Type{FactorRotation}, F::AbstractMatrix; ...) -> FactorRotation
+
+Fit a factor rotation to the matrix `F` and apply it. The algorithm used to
+perform the factor rotation is by default [`Orthomax`](@ref) and can be changed
+with the keyword argument `alg` which is of type `<:FactorRotationAlgorithm`.
+"""
+function fit(::Type{FactorRotation}, F::AbstractMatrix; 
+                       alg::T = Orthomax()) where {T <: FactorRotationAlgorithm}
+  if isa(alg, Orthomax)
+    F, R = orthomax(F, alg.γ, alg.miniter, alg.maxiter, alg.ϵ)
+    return FactorRotation(F, R, alg)
+  end
+end
+
+"""
+    fit(::Type{FactorRotation}, F::FactorAnalysis; ...) -> FactorRotation
+
+Fit a factor rotation to the loading matrix of the  [`FactorAnalysis`](@ref)
+object and apply it.
+
+See [`fit(::Type{FactorRotation}, F::AbstractMatrix)`](@ref) for keyword arguments.
+"""
+function fit(::Type{FactorRotation}, F::FactorAnalysis; 
+                       alg::T = Orthomax()) where {T <: FactorRotationAlgorithm}
+  return fit(FactorRotation, F.W; alg)
+end
+
+## Alternative interface
+
+"""
+    rotatefactors(F::AbstractMatrix, [alg::FactorRotationAlgorithm]) -> FactorRotation
+
+Rotate the factors in the matrix `F`. The algorithm to be used can be passed in
+via the second argument `alg`. By default [`Orthomax`](@ref) is used.
+"""
+function rotatefactors(F::AbstractMatrix, alg::FactorRotationAlgorithm = Orthomax())
+  F, R = _rotatefactors(F, alg)
+  return FactorRotation(F, R, alg)
+end
+
+# Use multiple dispatch to decide on the algorithm implementation
+
+function _rotatefactors(F::AbstractMatrix, alg::Orthomax)
+  return orthomax(F, alg.γ, alg.miniter, alg.maxiter, alg.ϵ)
+end
+
+"""
+    rotatefactors(F::FactorAnalysis, [alg::FactorRotationAlgorithm]) -> FactorAnalysis
+
+Rotate the factors in the loading matrix of `F` which is of type [`FactorAnalysis`](@ref).
+The algorithm to be used can be passed in via the second argument `alg`. 
+By default [`Orthomax`](@ref) is used.
+"""
+function rotatefactors(F::FactorAnalysis, alg::FactorRotationAlgorithm = Orthomax())
+  FR = rotatefactors(F.W, alg)
+  return FactorAnalysis(F.mean, FR.F, F.Ψ)
+end


### PR DESCRIPTION
This is a start to add factor rotations to MultivariateStats.jl. The implemented algorithm is currently what is described in the review paper

    Mikkel B. Stegmann, Karl Sjöstrand, Rasmus Larsen, 
    "Sparse modeling of landmark and texture variability using the orthomax criterion," 
    Proc. SPIE 6144, Medical Imaging 2006: Image Processing, 61441G (10 March 2006); 
    doi: 10.1117/12.651293

with the addition of choosing a random rotation matrix if the identity matrix is not a good starting point (this is what Matlab does in `rotatefactors` and was suggested by @haotian127).

Currently there are two suggestions for interfaces: Either the standard `fit` interface or `rotatefactors` which is more similar to Matlabs interface. I am not a big fan of the `fit` interface since, contrary to the scikit-learn original where it presumably came from, is not really chainable since keyword parameters differ from one `fit` function to the other. However, if this is the preferred way of adding things to MultivariateStats.jl then I will not stand in the way.

I like the idea of having a different type for each rotation algorithm. This is what JuliaBase started to do with e.g. the Algorithm for SVD as well. This way multiple dispatch can be used (as I currently have it in the `rotatefactors` interface) instead of a chain of `isa()` checks or checking a symbol switch such as `:orthomax`.

Many things are still missing

- [ ] Decide on proper interface: `fit` vs `rotatefactors`
- [ ] Helper functions? e.g. to access the rotation matrix or loadings in the returned `FactorRotation` object
- [ ] Is the special functionality for e.g. the `FactorAnalysis` object desirable?
- [ ] Add tests
- [ ] Add documentation to the Sphinx source
- [ ] Other rotations (oblique, based on GPA rotations, ...)
