### PR TITLE
Require `distances` keyword for MDS

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - linux
 julia:
     - 1.0
-    - 1.1
+    - 1
     - nightly
 notifications:
     email: false

--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,13 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
+[compat]
+Arpack = "0.3, 0.4"
+StatsBase = "0.29, 0.30, 0.31, 0.32, 0.33"
+
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
-
-[compat]
-StatsBase = ">=0.29"
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["multivariate statistics", "dimensionality reduction"]
 license = "MIT"
 desc = "A Julia package for multivariate statistics and data analysis"
 repository = "https://github.com/JuliaStats/MultivariateStats.jl.git"
-version = "0.7.0"
+version = "0.8.0"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"

--- a/src/cmds.jl
+++ b/src/cmds.jl
@@ -61,7 +61,7 @@ dmat2gram(D::AbstractMatrix{T}) where {T<:Real} = dmat2gram!(similar(D, momentty
 struct MDS{T<:Real}
     d::Real                  # original dimension
     X::AbstractMatrix{T}     # fitted data, X (d x n)
-    λ::AbstractVector{T}     # sqrt. eigenvalues in feature space, √λ (k x 1)
+    λ::AbstractVector{T}     # eigenvalues in feature space, (k x 1)
     U::AbstractMatrix{T}     # eigenvectors in feature space, U (n x k)
 end
 
@@ -122,9 +122,23 @@ end
 
 ## interface functions
 
+"""
+
+Compute an embedding of points by classical multidimensional scaling (MDS).
+There are two calling options, specified via the required keyword argument `distances`:
+
+    mds = fit(MDS, X; distances=false, maxdim=size(X,1)-1)
+
+`X` is the data matrix. Distances between pairs of columns of `X` are computed using the Euclidean norm.
+This is equivalent to performing PCA on `X`.
+
+    mds = fit(MDS, D; distances=true,  maxdim=size(D,1)-1)
+
+`D` is a symmetric matrix `D` of distances between points.
+"""
 function fit(::Type{MDS}, X::AbstractMatrix{T};
              maxoutdim::Int = size(X,1)-1,
-             distances=false) where T<:Real
+             distances::Bool) where T<:Real
 
     # get distance matrix and space dimension
     D, d = if !distances

--- a/test/cmds.jl
+++ b/test/cmds.jl
@@ -25,7 +25,8 @@ using Test
     @test gram2dmat(G) ≈ D0
 
     ## classical MDS
-    M = fit(MDS, X0, maxoutdim=3)
+    @test_throws UndefKeywordError fit(MDS, X0, maxoutdim=3)   # disambiguate distance matrix from data matrix
+    M = fit(MDS, X0, maxoutdim=3, distances=false)
     @test indim(M) == d
     @test outdim(M) == 3
     @test size(projection(M)) == (n,3)
@@ -84,7 +85,7 @@ using Test
     end
 
     #10 - test degenerate problem
-    @test transform(fit(MDS, zeros(10, 10), maxoutdim=3)) == zeros(3, 10)
+    @test transform(fit(MDS, zeros(10, 10), maxoutdim=3, distances=false)) == zeros(3, 10)
 
     # out-of-sample
     D = [0 1 2 1;


### PR DESCRIPTION
`fit(MDS, ...)` lacked documentation, and consequently I simply assumed
that one  passed a matrix of distances. This did not trigger any errors, but the
results were nonsense, because the distances matrix was interpreted as
a data matrix.

We can address this by requiring the user to provide the `distances` keyword.

Note that this is a **breaking change** and so I've taken liberty to bump the minor version.