### PR TITLE
Modernize struct names in docs

### DIFF
--- a/docs/source/mclda.rst
+++ b/docs/source/mclda.rst
@@ -74,7 +74,7 @@ The package defines a ``MulticlassLDA`` type to represent a multi-class LDA mode
 
 .. code-block:: julia
 
-    type MulticlassLDA
+    mutable struct MulticlassLDA
         proj::Matrix{Float64}
         pmeans::Matrix{Float64}
         stats::MulticlassLDAStats
@@ -205,7 +205,7 @@ Sometimes, it is useful to only perform one of these tasks. The package exposes 
 
     .. code-block:: julia
 
-        type MulticlassLDAStats
+        mutable struct MulticlassLDAStats
             dim::Int                    # sample dimensions
             nclasses::Int               # number of classes
             cweights::Vector{Float64}   # class weights
@@ -269,7 +269,7 @@ serves to regularize the computation.
 
 .. code-block:: julia
 
-    immutable SubspaceLDA{T<:Real}
+    struct SubspaceLDA{T<:Real}
         projw::Matrix{T}   # P, project down to the subspace spanned by within-class scatter
         projLDA::Matrix{T} # L, LDA directions in the projected subspace
         λ::Vector{T}

--- a/docs/source/whiten.rst
+++ b/docs/source/whiten.rst
@@ -18,7 +18,7 @@ The package uses ``Whitening`` defined below to represent a whitening transform:
 
 .. code-block:: julia
 
-    immutable Whitening{T<:FloatingPoint}
+    struct Whitening{T<:FloatingPoint}
         mean::Vector{T}     # mean vector (can be empty to indicate zero mean), of length d
         W::Matrix{T}        # the transform coefficient matrix, of size (d, d)
     end


### PR DESCRIPTION
Replaced the pre-0.6 type/immutable keywords in the .rst documentation with (mutable)
struct, so it now matches the code.