### PR TITLE
Relax type-asserts in PCA

### DIFF
--- a/src/pca.jl
+++ b/src/pca.jl
@@ -115,8 +115,8 @@ function pcasvd(Z::AbstractMatrix{T}, mean::Vector{T}, tw::Real;
 
     check_pcaparams(size(Z,1), mean, maxoutdim, pratio)
     Svd = svd(Z)
-    v = Svd.S::Vector{T}
-    U = Svd.U::Matrix{T}
+    v = Svd.S::AbstractVector{T}
+    U = Svd.U::AbstractMatrix{T}
     for i = 1:length(v)
         @inbounds v[i] = abs2(v[i]) / tw
     end


### PR DESCRIPTION
If you are accepting an AbstractMatrix in its not really fair to demand that `svd` give `Matrix` and `Vector` out.

Ideally I would like this to work with AxisArrays.jl's  KeyedArrays, but it would take more than this for that.
Would also need to change how the projection is stored.