### PR TITLE
Remove nonexistent export of invsqrtm

### DIFF
--- a/src/MultivariateStats.jl
+++ b/src/MultivariateStats.jl
@@ -29,7 +29,6 @@ module MultivariateStats
     Whitening,          # Type: Whitening transformation
 
     invsqrtm,           # Compute inverse of matrix square root, i.e. inv(sqrtm(A))
-    invsqrtm!,          # Compute inverse of matrix square root inplace
     cov_whitening,      # Compute a whitening transform based on covariance
     cov_whitening!,     # Compute a whitening transform based on covariance (input will be overwritten)
     invsqrtm,           # Compute C^{-1/2}, i.e. inv(sqrtm(C))


### PR DESCRIPTION
This export was added by 856bb6a even before the feature was introduced, and later 1010d72 added only `_invsqrtm!`. So this has never worked.