### PR TITLE
Add loadings to MDS

### DIFF
--- a/src/cmds.jl
+++ b/src/cmds.jl
@@ -73,6 +73,8 @@ outdim(M::MDS) = size(M.U,2)
 projection(M::MDS) = M.U
 eigvals(M::MDS) = M.λ
 
+loadings(M::MDS) = eigvals(M)' .* projection(M)
+
 ## use
 
 """Calculate out-of-sample multidimensional scaling transformation"""


### PR DESCRIPTION
Following #123 - confirmed that the output here is identical to old `classical_mds` function, though with rows/columns reversed.

For the sake of #109, should `eigvals` change to `principalvars` to match PCA?