### PR TITLE
Remove number of classes parameter from *-LDA

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -131,3 +131,13 @@ L2distance(X::AbstractMatrix{T}) where {T<:Real} = L2distance!(zeros(T,size(X,2)
 L2distance!(D::AbstractMatrix, X::AbstractMatrix) =
     pairwise!((x,y)->norm(x-y), D, eachcol(X), symmetric=true)
 
+"""
+    toindices(labels::AbstractVector)
+
+Generate integer indices for the collection `labels`. Generated indices will be
+in `1:nc` range where `nc` is a number of classes in the `labels` collection.
+"""
+function toindices(labels::AbstractVector)
+    idxs = Dict(l=>i for (i,l) in enumerate(unique(labels)))
+    [idxs[l] for l in labels]
+end

--- a/src/mmds.jl
+++ b/src/mmds.jl
@@ -23,11 +23,14 @@ which results in performing *metric MDS* with dissimilarities calculated as Eucl
 
 An arbitrary transformation function can be provided to `metric` parameter to
 perform metric MDS with transformed proximities. The function has to accept two parameters,
-a vector of proximities and a vector of distances, in order to calculate disparities
-required for stress calculation, e.g. *ratio MDS* using a ratio transformation
+a vector of proximities and a vector of distances, corresponding to the proximities, to calculate
+disparities required for stress calculation. Internally, the proximity and distance vectors are
+obtained from compact triangular matrix representation of proximity and distance matrices.
+
+For *ratio MDS*, a following ratio transformation function can be used
 
 ```julia
-mds = fit(MDS, D; distances=true, metric=(p,d)->2 .* p)
+mds = fit(MDS, D; distances=true, metric=((p,d)->2 .* p))
 ```
 
 For *order MDS*, use `isotonic` regression function in the `metric` parameter:

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -122,13 +122,13 @@ using Statistics: mean, cov
     ## MC-LDA
 
     for T in (Float32, Float64)
-        M = fit(MulticlassLDA, nc, convert(Matrix{T}, X), y; method=:gevd, regcoef=convert(T, lambda))
+        M = fit(MulticlassLDA, convert(Matrix{T}, X), y; method=:gevd, regcoef=convert(T, lambda))
         @test size(M) == (d, nc - 1)
         @test projection(M) ≈ P1
         @test M.pmeans ≈ M.proj'cmeans
         @test predict(M, X) ≈ M.proj'X
 
-        M = fit(MulticlassLDA, nc, convert(Matrix{T}, X), y; method=:whiten, regcoef=convert(T, lambda))
+        M = fit(MulticlassLDA, convert(Matrix{T}, X), y; method=:whiten, regcoef=convert(T, lambda))
         @test size(M) == (d, nc - 1)
         # @test projection(M) P2  # signs may change
         @test M.pmeans ≈ M.proj'cmeans
@@ -137,7 +137,7 @@ using Statistics: mean, cov
 
     # Issue #192
     XX = collect(X')
-    M = fit(MulticlassLDA, nc, XX', y)
+    M = fit(MulticlassLDA, XX', y)
     @test size(M) == (d, nc - 1)
 
     ## High-dimensional LDA (subspace LDA)
@@ -183,7 +183,7 @@ using Statistics: mean, cov
         @test proj'*Sw*proj ≈ Matrix(I,2,2)
 
         # also check that this is consistent with the conventional algorithm
-        Mld = fit(MulticlassLDA, 3, X, label)
+        Mld = fit(MulticlassLDA, X, label)
         for i = 1:2
             @test abs(dot(normalize(proj[:,i]), normalize(Mld.proj[:,i]))) ≈ 1
         end
@@ -213,7 +213,7 @@ using Statistics: mean, cov
     centers = M.cmeans
     dcenters = centers .- mean(X, dims=2)
     Hb = dcenters*Diagonal(sqrt.(M.cweights))
-    Hw = X - centers[:,label]
+    Hw = X - centers[:, MultivariateStats.toindices(label)]
     @test (M.projw'*Hb)*(Hb'*M.projw)*M.projLDA ≈ (M.projw'*Hw)*(Hw'*M.projw)*M.projLDA*Diagonal(M.λ)
 
     # Test normalized LDA

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -250,7 +250,7 @@ using Statistics: mean, cov
         M = fit(SubspaceLDA, convert(Matrix{T}, X), label; normalize=nrm)
         proj = projection(M)
         @test eltype(proj) === T
-        tol = T === Float64 ? 1e-10 : 5e-4
+        tol = T === Float64 ? 1e-10 : 5e-3
         Hb = centers .- mean(centers, dims=2)
         if nrm
             @test Hb*Hb'*proj ≈ (dX*dX'/(n1+n2))*proj*Diagonal(M.λ) atol=tol

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -75,7 +75,7 @@ using Statistics: mean, cov
 
     ## Stats
 
-    S = multiclass_lda_stats(nc, X, y)
+    S = multiclass_lda_stats(X, y)
 
     @test S.dim == d
     @test S.nclasses == nc
@@ -88,7 +88,7 @@ using Statistics: mean, cov
     @test betweenclass_scatter(S) ≈ Sb
 
     covestimator = SimpleCovariance(corrected=true)
-    Sce = multiclass_lda_stats(nc, X, y; covestimator_between=covestimator, covestimator_within=covestimator)
+    Sce = multiclass_lda_stats(X, y; covestimator_between=covestimator, covestimator_within=covestimator)
 
     Swcorr = Sw * sum(ns)/(sum(ns)-1)
     Sbcorr = Sb * nc/(nc-1)


### PR DESCRIPTION
Previously, in MC-LDA & SubLDA, labels required to be from a set of integers in the range `1:nc` where `nc` is a total number of classes. That created a problem when some labels in this range where not present in the label collection. e.g. `[1,1,3,3,3]` label collection has two classes but maximum value of label is `3`. This was intentional design decision because label set was used for indexing features during calculation of feature centers. Thus, to avoid incorrect indexing the number of classes parameter was used.
This PR removes the "number of classes" parameter and estimates a number of classes from a number of unique labels. Additionally, PR removes type limitation on label collection.