### PR TITLE
Detection of degenerate between-class covariance matrix

### DIFF
--- a/src/lda.jl
+++ b/src/lda.jl
@@ -477,7 +477,7 @@ function fit(::Type{SubspaceLDA}, X::AbstractMatrix{T},
     # (essentially, PCA before LDA)
     Uw, Σw, _ = svd(Hw, full=false)
     keep = Σw .> sqrt(eps(T)) * maximum(Σw)
-    count(keep) > 0 || throw(error("within-class covariance matrix is null"))
+    count(keep) > 0 || error("within-class covariance matrix is null")
     projw = Uw[:,keep]
     pHb = projw' * Hb
     pHw = projw' * Hw

--- a/src/lda.jl
+++ b/src/lda.jl
@@ -513,7 +513,7 @@ function lda_gsvd(Hb::AbstractMatrix{T}, Hw::AbstractMatrix{T}, cweights::Abstra
     # Normalize
     Gw = G' * Hw
     nrm = Gw * Gw'
-    G = G ./ reshape(sqrt.(diag(nrm)), 1, ncnz-1)
+    G = G ./ reshape(sqrt.(diag(nrm)), 1, size(G, 2))
     # Also get the eigenvalues
     Gw = G' * Hw
     Gb = G' * Hb

--- a/src/lda.jl
+++ b/src/lda.jl
@@ -477,16 +477,12 @@ function fit(::Type{SubspaceLDA}, X::AbstractMatrix{T},
     # (essentially, PCA before LDA)
     Uw, Σw, _ = svd(Hw, full=false)
     keep = Σw .> sqrt(eps(T)) * maximum(Σw)
-    count(keep) > 0 || throw(NullMatrixException("within-class covariance matrix is null"))
+    count(keep) > 0 || throw(error("within-class covariance matrix is null"))
     projw = Uw[:,keep]
     pHb = projw' * Hb
     pHw = projw' * Hw
     λ, G = lda_gsvd(pHb, pHw, cweights)
     SubspaceLDA(projw, G, λ, cmeans, cweights)
-end
-
-struct NullMatrixException <: Exception
-    msg::String
 end
 
 # Reference: Howland & Park (2006), "Generalizing discriminant analysis

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -216,6 +216,26 @@ using Statistics: mean, cov
     Hw = X - centers[:, MultivariateStats.toindices(label)]
     @test (M.projw'*Hb)*(Hb'*M.projw)*M.projLDA ≈ (M.projw'*Hw)*(Hw'*M.projw)*M.projLDA*Diagonal(M.λ)
 
+    # Test for case when `rank(Sw) < nlabels - 1` see issue #200
+    labels1 = [1, 2, 3, 2, 4]
+    X1 = rand(5, 5)
+    M = fit(SubspaceLDA, X, label)
+    centers = M.cmeans
+    dcenters = centers .- mean(X, dims=2)
+    Hb = dcenters*Diagonal(sqrt.(M.cweights))
+    Hw = X - centers[:, MultivariateStats.toindices(label)]
+    @test (M.projw'*Hb)*(Hb'*M.projw)*M.projLDA ≈ (M.projw'*Hw)*(Hw'*M.projw)*M.projLDA*Diagonal(M.λ)
+
+    # test errors that are expected while fitting SubspaceLDA model
+    s = rand(2, 1)
+    X2 = [s 2s 3s 2s 5s]
+    labels2 = [1,2,3,4, 5]
+    @test_throws ArgumentError fit(SubspaceLDA, X2, labels2)
+    labels3 = [1,2,3,2, 4]
+    @test_throws MultivariateStats.NullMatrixException fit(SubspaceLDA, X2, labels3)
+    labels4 = [1, 2, 3]
+    @test_throws DimensionMismatch fit(SubspaceLDA, X2, labels4)
+
     # Test normalized LDA
     function gen_ldadata_2(centers, n1, n2)
         d = size(centers, 1)

--- a/test/mclda.jl
+++ b/test/mclda.jl
@@ -232,7 +232,7 @@ using Statistics: mean, cov
     labels2 = [1,2,3,4, 5]
     @test_throws ArgumentError fit(SubspaceLDA, X2, labels2)
     labels3 = [1,2,3,2, 4]
-    @test_throws MultivariateStats.NullMatrixException fit(SubspaceLDA, X2, labels3)
+    @test_throws ErrorException fit(SubspaceLDA, X2, labels3)
     labels4 = [1, 2, 3]
     @test_throws DimensionMismatch fit(SubspaceLDA, X2, labels4)
 


### PR DESCRIPTION
This PR resolves #200. 
It also includes a new exception called `NullMatrixException` which is thrown when a null matrix is detected at run-time. 
Additionally, Efforts have been made to detect the case when the between-class covariance matrix is null (i.e the zero matrix) based on the input to the `fit(SubspaceLDA, ...)` function. For example when the number of classes/labels equals the number of samples, the  resulting between-class covariance matrix is null, since in computing `Hw` there is only one member per class group which is then subtracted from itself when centering the data.
cc. @ablaom @wildart 