### PR TITLE
MulticlassLDA documentation

### DIFF
--- a/docs/src/lda.md
+++ b/docs/src/lda.md
@@ -10,6 +10,49 @@ Suppose the samples in the positive and negative classes respectively with means
 ```
 Here ``\alpha`` is an arbitrary non-negative coefficient.
 
+## Example
+
+```@setup MulticlassLDAex
+using Plots
+gr(fmt=:svg)
+```
+
+Let's compare LDA and PCA 2D projection of Iris dataset. Principal Component Analysis identifies the directions that explain the most variance in the data. 
+
+```@example MulticlassLDAex
+using MultivariateStats, RDatasets
+
+iris = dataset("datasets", "iris")
+
+X = Matrix(iris[1:2:end,1:4])'
+X_labels = Vector(iris[1:2:end,5])
+
+pca = fit(PCA, X; maxoutdim=2)
+Ypca = predict(pca, X)
+nothing # hide
+```
+
+In contrast,
+Linear Discriminant Analysis attempts to identify the attributes that account for the most variance between classes. Therefore, with LDA, you must use known class labels.
+
+```@example MulticlassLDAex
+lda = fit(MulticlassLDA, X, X_labels; outdim=2)
+Ylda = predict(lda, X)
+
+p = plot(layout=(1,2), size=(800,300))
+
+for s in ["setosa", "versicolor", "virginica"]
+
+    points = Ypca[:,X_labels.==s]
+    scatter!(p[1], points[1,:],points[2,:], label=s, legend=:bottomleft)
+    points = Ylda[:,X_labels.==s]
+    scatter!(p[2], points[1,:],points[2,:], label=s, legend=:bottomleft)
+
+end
+plot!(p[1], title="PCA")
+plot!(p[2], title="LDA")
+```
+
 ## Two-class Linear Discriminant Analysis
 
 This package uses the [`LinearDiscriminant`](@ref) type to capture a linear discriminant functional:
@@ -160,45 +203,3 @@ length(::SubspaceLDA)
 eigvals(::SubspaceLDA)
 ```
 
-## Example
-
-```@setup MulticlassLDAex
-using Plots
-gr(fmt=:svg)
-```
-
-Let's compare LDA and PCA 2D projection of Iris dataset. Principal Component Analysis identifies the directions that explain the most variance in the data. 
-
-```@example MulticlassLDAex
-using MultivariateStats, RDatasets
-
-iris = dataset("datasets", "iris")
-
-X = Matrix(iris[1:2:end,1:4])'
-X_labels = Vector(iris[1:2:end,5])
-
-pca = fit(PCA, X; maxoutdim=2)
-Ypca = predict(pca, X)
-nothing # hide
-```
-
-In contrast,
-Linear Discriminant Analysis attempts to identify the attributes that account for the most variance between classes. Therefore, with LDA, you must use known class labels.
-
-```@example MulticlassLDAex
-lda = fit(MulticlassLDA, X, X_labels; outdim=2)
-Ylda = predict(lda, X)
-
-p = plot(layout=(1,2), size=(800,300))
-
-for s in ["setosa", "versicolor", "virginica"]
-
-    points = Ypca[:,X_labels.==s]
-    scatter!(p[1], points[1,:],points[2,:], label=s, legend=:bottomleft)
-    points = Ylda[:,X_labels.==s]
-    scatter!(p[2], points[1,:],points[2,:], label=s, legend=:bottomleft)
-
-end
-plot!(p[1], title="PCA")
-plot!(p[2], title="LDA")
-```

--- a/docs/src/lda.md
+++ b/docs/src/lda.md
@@ -194,11 +194,9 @@ p = plot(layout=(1,2), size=(800,300))
 for s in ["setosa", "versicolor", "virginica"]
 
     points = Ypca[:,X_labels.==s]
-    scatter!(p[1], points[1,:],points[2,:],marker=:circle,linewidth=0, 
-             label=s, legend=:bottomleft)
+    scatter!(p[1], points[1,:],points[2,:], label=s, legend=:bottomleft)
     points = Ylda[:,X_labels.==s]
-    scatter!(p[2], points[1,:],points[2,:],marker=:circle,linewidth=0, 
-             label=s, legend=:bottomleft)
+    scatter!(p[2], points[1,:],points[2,:], label=s, legend=:bottomleft)
 
 end
 plot!(p[1], title="PCA")

--- a/docs/src/lda.md
+++ b/docs/src/lda.md
@@ -107,7 +107,7 @@ MulticlassLDAStats
 Several methods are provided to access properties of the LDA model. Let `M` be an instance of `MulticlassLDA`:
 
 ```@docs
-fit(::Type{MulticlassLDA}, ::Int, ::DenseMatrix{T}, ::AbstractVector{Int}; kwargs...) where T<:Real
+fit(::Type{MulticlassLDA}, ::DenseMatrix{T}, ::AbstractVector; kwargs...) where T<:Real
 predict(::MulticlassLDA, ::AbstractVecOrMat{T}) where {T<:Real}
 mean(::MulticlassLDA)
 size(::MulticlassLDA)

--- a/docs/src/lda.md
+++ b/docs/src/lda.md
@@ -107,7 +107,7 @@ MulticlassLDAStats
 Several methods are provided to access properties of the LDA model. Let `M` be an instance of `MulticlassLDA`:
 
 ```@docs
-fit(::Type{MulticlassLDA}, ::DenseMatrix{T}, ::AbstractVector; kwargs...) where T<:Real
+fit(::Type{MulticlassLDA}, ::AbstractMatrix{T}, ::AbstractVector; kwargs...) where T<:Real
 predict(::MulticlassLDA, ::AbstractVecOrMat{T}) where {T<:Real}
 mean(::MulticlassLDA)
 size(::MulticlassLDA)
@@ -151,11 +151,56 @@ SubspaceLDA
 Several methods are provided to access properties of the LDA model. Let `M` be an instance of [`SubspaceLDA`](@ref):
 
 ```@docs
-fit(::Type{SubspaceLDA}, ::DenseMatrix{T}, ::AbstractVector{Int}, ::Int; kwargs...) where T<:Real
+fit(::Type{SubspaceLDA}, ::AbstractMatrix{T}, ::AbstractVector; kwargs...) where T<:Real
 predict(::SubspaceLDA, ::AbstractVecOrMat{T}) where {T<:Real}
 mean(::SubspaceLDA)
 projection(::SubspaceLDA)
 size(::SubspaceLDA)
 length(::SubspaceLDA)
 eigvals(::SubspaceLDA)
+```
+
+## Example
+
+```@setup MulticlassLDAex
+using Plots
+gr(fmt=:svg)
+```
+
+Let's compare LDA and PCA 2D projection of Iris dataset. Principal Component Analysis identifies the directions that explain the most variance in the data. 
+
+```@example MulticlassLDAex
+using MultivariateStats, RDatasets
+
+iris = dataset("datasets", "iris")
+
+X = Matrix(iris[1:2:end,1:4])'
+X_labels = Vector(iris[1:2:end,5])
+
+pca = fit(PCA, X; maxoutdim=2)
+Ypca = predict(pca, X)
+nothing # hide
+```
+
+In contrast,
+Linear Discriminant Analysis attempts to identify the attributes that account for the most variance between classes. Therefore, with LDA, you must use known class labels.
+
+```@example MulticlassLDAex
+lda = fit(MulticlassLDA, X, X_labels; outdim=2)
+Ylda = predict(lda, X)
+
+p = plot(layout=(1,2), size=(800,300))
+
+for s in ["setosa", "versicolor", "virginica"]
+
+    points = Ypca[:,X_labels.==s]
+    scatter!(p[1], points[1,:],points[2,:],marker=:circle,linewidth=0, 
+             label=s, legend=:bottomleft)
+    points = Ylda[:,X_labels.==s]
+    scatter!(p[2], points[1,:],points[2,:],marker=:circle,linewidth=0, 
+             label=s, legend=:bottomleft)
+
+end
+plot!(p[1], title="PCA")
+plot!(p[2], title="LDA")
 ```

--- a/src/lda.jl
+++ b/src/lda.jl
@@ -284,7 +284,7 @@ Transform input sample(s) in `x` to the output space of MC-LDA model `M`. Here, 
 predict(M::MulticlassLDA, x::AbstractVecOrMat{T}) where {T<:Real} = M.proj'x
 
 """
-    fit(Type{MulticlassLDA}, X, y; ...)
+    fit(MulticlassLDA, X, y; ...)
 
 Perform multi-class LDA over a given data set `X` with corresponding labels `y`
 with `nc` number of classes.

--- a/src/lda.jl
+++ b/src/lda.jl
@@ -284,7 +284,7 @@ Transform input sample(s) in `x` to the output space of MC-LDA model `M`. Here, 
 predict(M::MulticlassLDA, x::AbstractVecOrMat{T}) where {T<:Real} = M.proj'x
 
 """
-    fit(MulticlassLDA, X, y; ...)
+    fit(Type{MulticlassLDA}, X, y; ...)
 
 Perform multi-class LDA over a given data set `X` with corresponding labels `y`
 with `nc` number of classes.


### PR DESCRIPTION
The documentation of `fit` function for MulticlassLDA wasn't displayed.
I think i fixed it. There is no example for LDA so i made a simple one but I am not sure you want it.
I can add it to the PR it you are interested. This is the scikit-learn example though.

```julia
using MultivariateStats, RDatasets, Plots

iris = dataset("datasets", "iris")

X = Matrix(iris[1:2:end,1:4])'
X_labels = Vector(iris[1:2:end,5])

pca = fit(PCA, X; maxoutdim=2)
Ypca = predict(pca, X)

lda = fit(MulticlassLDA, X, X_labels; outdim=2)
Ylda = predict(lda, X)

p = plot(layout=(1,2), size=(900,300))

for s in ["setosa", "versicolor", "virginica"]

    points = Ypca[:,X_labels.==s]
    scatter!(p[1], points[1,:],points[2,:],marker=:circle,linewidth=0, 
             label=s, legend=:bottomleft)
    points = Ylda[:,X_labels.==s]
    scatter!(p[2], points[1,:],points[2,:],marker=:circle,linewidth=0, 
             label=s, legend=:bottomleft)

end
display(p)
```