### PR TITLE
Bug fix & documentation: KernelPCA w/ precomputed X

### DIFF
--- a/docs/source/kpca.rst
+++ b/docs/source/kpca.rst
@@ -68,6 +68,9 @@ One can use the ``fit`` method to perform kernel PCA over a given dataset.
 
                 This functions accepts two vector arguments ``x`` and ``y``,
                 and returns a scalar value.
+                
+                If ``X`` is a precomputed kernel matrix (Gramian), set 
+                ``kernel=nothing``.
     ----------- --------------------------------------------------------------- ---------------
      solver     The choice of solver:                                            ``:eig``
 

--- a/src/kpca.jl
+++ b/src/kpca.jl
@@ -132,7 +132,8 @@ This method returns an instance of [`KernelPCA`](@ref).
 Let `(d, n) = size(X)` be respectively the input dimension and the number of observations:
 
 - `kernel`: The kernel function. This functions accepts two vector arguments `x` and `y`,
-and returns a scalar value (*default:* `(x,y)->x'y`)
+and returns a scalar value (*default:* `(x,y)->x'y`). If set to `nothing`, the matrix `X` is
+the pre-computed symmetric kernel (Gram) matrix.
 - `solver`: The choice of solver:
     - `:eig`: uses `LinearAlgebra.eigen` (*default*)
     - `:eigs`: uses `Arpack.eigs` (always used for sparse data)

--- a/src/kpca.jl
+++ b/src/kpca.jl
@@ -159,7 +159,7 @@ function fit(::Type{KernelPCA}, X::AbstractMatrix{T};
     elseif kernel === nothing
         @assert issymmetric(X) "Precomputed kernel matrix must be symmetric."
         inverse = false
-        X
+        copy(X)
     else
         throw(ArgumentError("Incorrect kernel type. Use a function or a precomputed kernel."))
     end


### PR DESCRIPTION
Bug: `fit(KernelPCA, X; kernel=nothing)` mutates `X` via `K = X` prior to calling `transform!` on `K`
Fix: `K = copy(X)`

Documentation also does not mention the use of `kernel=nothing` when `X` is a pre-computed Gramian; added this.
