### PR TITLE
Matrixify `qr.Q` instead `collect`ing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ keywords = ["multivariate statistics", "dimensionality reduction"]
 license = "MIT"
 desc = "A Julia package for multivariate statistics and data analysis"
 repository = "https://github.com/JuliaStats/MultivariateStats.jl.git"
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"

--- a/test/pca.jl
+++ b/test/pca.jl
@@ -71,7 +71,7 @@ import SparseArrays
     d = 5
     n = 1000
 
-    R = collect(qr(randn(rng, d, d)).Q)
+    R = Matrix(qr(randn(rng, d, d)).Q)
     @test R'R ≈ Matrix(I, 5, 5)
     rmul!(R, Diagonal(sqrt.([0.5, 0.3, 0.1, 0.05, 0.05])))
 


### PR DESCRIPTION
This is in preparation for https://github.com/JuliaLang/julia/pull/46196. Collecting index by index is relatively expensive compared to computing the entire matrix at once. Even though this is just a change in a test, I suggest to bump the patch version and to release it, so that nanosoldier tests can pick up the change.