### PR TITLE
allow a bit of absolute tolerance deviation in a test,

### DIFF
--- a/test/kpca.jl
+++ b/test/kpca.jl
@@ -30,7 +30,7 @@ import Statistics: mean, cov
         Z = K - I1*K - K*I2 + I1*K*I2
 
         KC = fit(MultivariateStats.KernelCenter, K)
-        @test all(Z .≈ MultivariateStats.transform!(KC, copy(K)))
+        @test all(.≈(Z, MultivariateStats.transform!(KC, copy(K)); atol=1e-12))
     end
 
     # kernel calculations


### PR DESCRIPTION
otherwise, we require absolute equality when one of the values are 0.0

Due to the following difference in 1.11, this test otherwise fails:

```julia
julia> K = reshape(1.:12., 3, 4)
3×4 reshape(::StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}, 3, 4) with eltype Float64:
 1.0  4.0  7.0  10.0
 2.0  5.0  8.0  11.0
 3.0  6.0  9.0  12.0

julia> x, y = size(K)
(3, 4)

julia> I1 = ones(x,x)/x
3×3 Matrix{Float64}:
 0.333333  0.333333  0.333333
 0.333333  0.333333  0.333333
 0.333333  0.333333  0.333333

# 1.11
julia> (- I1*K)[1,4]
-10.999999999999998

# 1.10
julia> (- I1*K)[1,4]
-11.0
```