### PR TITLE
Fix DimensionMismatch in `loadings`

### DIFF
--- a/src/cmds.jl
+++ b/src/cmds.jl
@@ -135,7 +135,7 @@ projection(M::MDS) = M.U
 """
     eigvecs(M::MDS)
 
-Get the MDS model `M` eigenvectors matrix. 
+Get the MDS model `M` eigenvectors matrix.
 """
 eigvecs(M::MDS) = projection(M)
 
@@ -151,7 +151,7 @@ eigvals(M::MDS) = M.λ
 
 Get the loading of the MDS model `M`.
 """
-loadings(M::MDS) = sqrt.(M.λ)' .* M.U
+loadings(M::MDS) = sqrt.(M.λ)' .* M.U[:,eachindex(M.λ)]
 
 ## use
 

--- a/test/cmds.jl
+++ b/test/cmds.jl
@@ -156,5 +156,12 @@ using StableRNGs
     M = fit(MetricMDS, Δ, maxoutdim=2, distances=true, initial=Z, metric=isotonic, tol=1e-6)
     @test stress(M) ≈ 0.234 atol=1e-2
 
+    # loadings when the Gramian has fewer positive eigenvalues than there are points
+    X = randn(2, 100)
+    D = [norm(x - y) for x in eachcol(X), y in eachcol(X)]
+    M = fit(MDS, D; distances=true)
+    @test length(eigvals(M)) < 99   # check that this test is checking what we want it to check
+    Y = loadings(M)
+    @test size(Y) == (100, length(eigvals(M)))
 end
 


### PR DESCRIPTION
When the embedding has a number of zero eigenvalues, `λ` gets truncated.
However, `U` does not, and thus `loadings` throws a `DimensionMismatch`
error on master. This fixes that error.

Alternatively, we could truncate `U` as well, but retaining the full `U`
matrix makes it easier to obtain a full orthonormal basis, if desired.