### PR TITLE
Add the option to ignore `ConvergenceExceptions` (#233)

### DIFF
--- a/src/mmds.jl
+++ b/src/mmds.jl
@@ -113,6 +113,7 @@ Let `(d, n) = size(X)` be respectively the input dimension and the number of obs
     - any two parameter disparity transformation function, where the first parameter is a vector of proximities (i.e. dissimilarities) and the second parameter is a vector of distances, e.g. `(p,d)->b*p` for some `b` is a transformation function for *ratio* MDS.
 - `tol`: Convergence tolerance (*default* `1.0e-3`)
 - `maxiter`: Maximum number of iterations (*default* `300`)
+- `omit_convergence_exception`: Whether to omit an exception if the function did not converge (*default* `false`).
 - `initial`: an initial reduced space point configuration
     - `nothing`: then an initial configuration is randomly generated (*default*)
     - pre-defined matrix
@@ -129,7 +130,8 @@ function fit(::Type{MetricMDS}, X::AbstractMatrix{T};
              maxiter::Int = 300,
              initial::Union{Nothing,AbstractMatrix{<:Real}} = nothing,
              weights::Union{Nothing,AbstractMatrix{<:Real}} = nothing,
-             distances::Bool) where {T<:Real}
+             distances::Bool,
+             omit_convergence_exception::Bool = false) where {T<:Real}
 
     # get distance matrix and space dimension
     Δ, d = if !distances
@@ -204,7 +206,10 @@ function fit(::Type{MetricMDS}, X::AbstractMatrix{T};
         σ′ = σ
         i += 1
     end
-    converged || throw(ConvergenceException(maxiter, chg, oftype(chg, tol)))
+
+    if !omit_convergence_exception && !converged
+        throw(ConvergenceException(maxiter, chg, oftype(chg, tol)))
+    end
 
     MetricMDS(d, Z, σ′)
 end

--- a/test/ica.jl
+++ b/test/ica.jl
@@ -85,6 +85,7 @@ using StatsBase: ConvergenceException
         @test W'C * W ≈ Matrix(I, k, k)
 
         @test_throws ConvergenceException fit(ICA, X, k; do_whiten=true, tol=1e-8, maxiter=2)
+        _ = fit(ICA, X, k; do_whiten=true, tol=1e-8, maxiter=2, omit_convergence_exception=true)
 
         # Use data of different type
         XX = convert(Matrix{Float32}, X)

--- a/test/ppca.jl
+++ b/test/ppca.jl
@@ -113,6 +113,7 @@ import StatsBase
     @test P'P ≈ Matrix(I, 3, 3)
 
     @test_throws StatsBase.ConvergenceException fit(PPCA, X; method=:em, maxiter=1)
+    _ = fit(PPCA, X; method=:em, maxiter=1, omit_convergence_exception=true)
 
     # bayespca
     M0 = fit(PCA, X; mean=mval, maxoutdim = 3)
@@ -139,6 +140,7 @@ import StatsBase
     @test P'P ≈ Matrix(I, 2, 2)
 
     @test_throws StatsBase.ConvergenceException fit(PPCA, X; method=:bayes, maxiter=1)
+    _ = fit(PPCA, X; method=:bayes, maxiter=1, omit_convergence_exception=true)
 
     # Different data types
     # --------------------


### PR DESCRIPTION
The result of a non-converged model might still be interesting. However, since `ConvergenceExceptions` are thrown, these partially fitted models are discarded.

This commit adds a `omit_convergence_exception` argument to all relevant functions that allows the user to omit such exceptions and return the partially trained model. The exception is still thrown in the default case to preserve backwards compatibility.