### PR TITLE
Fix reconstruct: throw ArgumentError on invalid input type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         env:
           cache-name: cache-artifacts
         with:

--- a/docs/src/pca.md
+++ b/docs/src/pca.md
@@ -117,6 +117,10 @@ predict(::KernelPCA)
 predict(::KernelPCA, ::AbstractVecOrMat{T}) where {T<:Real}
 reconstruct(::KernelPCA, ::AbstractVecOrMat{T}) where {T<:Real}
 size(::KernelPCA)
+```
+!!! note
+	If `reconstruct` is called with an input that is not an `AbstractVecOrMat` of real numbers, an `ArgumentError` is thrown indicating the invalid input type and the expected type.
+```
 projection(::KernelPCA)
 eigvals(::KernelPCA)
 eigvecs(::KernelPCA)
@@ -164,6 +168,10 @@ fit
 size(::PPCA)
 mean(::PPCA)
 var(::PPCA)
+```
+!!! note
+	If `reconstruct` is called with an input that is not an `AbstractVecOrMat` of real numbers, an `ArgumentError` is thrown indicating the invalid input type and the expected type.
+```
 cov(::PPCA)
 projection(::PPCA)
 loadings(::PPCA)
@@ -188,6 +196,9 @@ Here, ``\mathbf{W}`` is the factor loadings or weight matrix.
 predict(::PPCA, ::AbstractVecOrMat{T}) where {T<:Real}
 reconstruct(::PPCA, ::AbstractVecOrMat{T}) where {T<:Real}
 ```
+```
+!!! note
+	If `reconstruct` is called with an input that is not an `AbstractVecOrMat` of real numbers, an `ArgumentError` is thrown indicating the invalid input type and the expected type.
 
 Auxiliary functions:
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -23,8 +23,14 @@ projection(model::AbstractDimensionalityReduction) = error("'projection' is not 
     reconstruct(model::AbstractDimensionalityReduction, y)
 
 Return the model response (a.k.a. the dependent variable).
+Throws an `ArgumentError` if `y` is not an `AbstractVecOrMat` of real numbers, indicating the invalid 
+input type and the expected type.
 """
-reconstruct(model::AbstractDimensionalityReduction, y) = error("'reconstruct' is not defined for $(typeof(model)).")
+function reconstruct(model::AbstractDimensionalityReduction, y)
+    throw(ArgumentError("Invalid input type $(typeof(y)) for reconstruct(::$(typeof(model))). " * 
+    "Expected an AbstractVecOrMat of real numbers."
+    ))
+end
 
 abstract type LinearDimensionalityReduction <: AbstractDimensionalityReduction end
 

--- a/test/pca.jl
+++ b/test/pca.jl
@@ -43,6 +43,12 @@ import SparseArrays
     @test reconstruct(M, Y[:,1]) ≈ P * Y[:,1]
     @test reconstruct(M, Y) ≈ P * Y
 
+    @test_throws ArgumentError reconstruct(M, 123)
+    @test_throws ArgumentError reconstruct(M, Dict())
+    @test_throws ArgumentError reconstruct(M, "abc")
+    @test_throws ArgumentError reconstruct(M, 8923.29)
+    @test_throws ArgumentError reconstruct(M, 1+2im)
+
 
     ## PCA with non-zero mean
 


### PR DESCRIPTION
<h2>Summary</h2>
This PR addresses the issue #238 by improving the error handling in the fallback reconstruct method for dimensionality reduction models.
Now, whenever it is called with an input which is not an AbstractVecOrMat of real numbers, an ArgumentError is thrown with a clear message which helps user to know the invalid input type and the expected input type.  


<br> This closes the issue #238 

<hr>
<h2>Approach</h2>
Following is the way of my approach which ensures users  receive clear, actionable feedback
and aligns with Julia's best practices for error handling.

- Confirmed that the fallback reconstruct method previously gave a misleading error when it was called with an invalid input type.

- Replace the generic error with a more meaningful, specific and reasonable error which clearly states the received and expected types.

- Updated the necessary documentation and docstring for it.

- Added and verified tests to ensure the new error is raised for invalid input types.
<hr>
<h2>Tests</h2>
All tests pass.
<hr>
<h2>Notes</h2>
<i><h3>I have attached images showing that the tests are passing</h3></i>
<h4>Images: </h4>
<br>
<img width="1318" height="988" alt="image" src="https://github.com/user-attachments/assets/33fcb18f-dd31-4dbb-bd89-6ca0fe709879" />
<br>
<img width="1319" height="971" alt="image" src="https://github.com/user-attachments/assets/e3059966-68d1-4d76-a001-e70450fde6fb" />
<br>
<img width="1170" height="682" alt="image" src="https://github.com/user-attachments/assets/baca9d67-97ab-442d-a876-e99aaf0ed2cb" />
<br>
Feedbacks are welcome.

